### PR TITLE
Store the start time of slow requests.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# 0.1.1
+
+* Store the start time of slow requests.
+
 # 0.1.0
 
 * Boom.

--- a/lib/scout_apm/slow_transaction.rb
+++ b/lib/scout_apm/slow_transaction.rb
@@ -2,7 +2,7 @@ class ScoutApm::SlowTransaction
   BACKTRACE_THRESHOLD = 0.5 # the minimum threshold to record the backtrace for a metric.
   BACKTRACE_LIMIT = 5 # Max length of callers to display
   MAX_SIZE = 100 # Limits the size of the metric hash to prevent a metric explosion.
-  attr_reader :metric_name, :total_call_time, :metrics, :meta, :uri, :context
+  attr_reader :metric_name, :total_call_time, :metrics, :meta, :uri, :context, :time
   
   # Given a call stack, generates a filtered backtrace that:
   # * Limits to the app/models, app/controllers, or app/views directories
@@ -19,12 +19,13 @@ class ScoutApm::SlowTransaction
     stack
   end
   
-  def initialize(uri,metric_name,total_call_time,metrics,context)
+  def initialize(uri,metric_name,total_call_time,metrics,context,time)
     @uri = uri
     @metric_name = metric_name
     @total_call_time = total_call_time
     @metrics = metrics
     @context = context
+    @time = time
   end
 
   # Used to remove metrics when the payload will be too large.

--- a/lib/scout_apm/store.rb
+++ b/lib/scout_apm/store.rb
@@ -137,8 +137,9 @@ class ScoutApm::Store
     @slow_transaction_lock.synchronize do
       # tree map of all slow transactions
       if parent_stat.total_call_time >= 2
-        @slow_transactions.push(ScoutApm::SlowTransaction.new(uri,parent_meta.metric_name,parent_stat.total_call_time,transaction_hash.dup,ScoutApm::Context.current))
-        ScoutApm::Agent.instance.logger.debug "Slow transaction sample added. [URI: #{uri}] [Context: #{ScoutApm::Context.current.to_hash}] Array Size: #{@slow_transactions.size}"      end
+        @slow_transactions.push(ScoutApm::SlowTransaction.new(uri,parent_meta.metric_name,parent_stat.total_call_time,transaction_hash.dup,ScoutApm::Context.current,Thread::current[:scout_apm_trace_time]))
+        ScoutApm::Agent.instance.logger.debug "Slow transaction sample added. [URI: #{uri}] [Context: #{ScoutApm::Context.current.to_hash}] Array Size: #{@slow_transactions.size}"      
+      end
     end
   end
   

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,3 +1,3 @@
 module ScoutApm
-  VERSION = "0.1"
+  VERSION = "0.1.1.pre"
 end


### PR DESCRIPTION
Stores the start time of slow requests in `SlowTransaction#time`. 
