### PR TITLE
Using ActiveRecord::Base.configurations in Rails 3-4

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# 1.2.9
+
+* Uses ActiveRecord::Base.configurations to access database adapter across all versions of Rails 3.0+.
+
 # 1.2.8
 
 * Enhance shutdown code to be sure we save current-minute metrics and minimize

--- a/lib/scout_apm/framework_integrations/rails_3_or_4.rb
+++ b/lib/scout_apm/framework_integrations/rails_3_or_4.rb
@@ -36,7 +36,7 @@ module ScoutApm
         default = :mysql
 
         if defined?(ActiveRecord::Base)
-          adapter = getDatabaseAdapter # can be nil
+          adapter = get_database_adapter # can be nil
 
           case adapter.to_s
           when "postgres"   then :postgres
@@ -52,13 +52,9 @@ module ScoutApm
         end
       end
 
-      def getDatabaseAdapter
-        if ActiveRecord::Base.respond_to?(:connection_config)
-          ActiveRecord::Base.connection_config[:adapter]
-        elsif ActiveRecord::Base.respond_to?(:configurations)
-          ActiveRecord::Base.configurations[env]["adapter"]
-        end
-      rescue
+      def get_database_adapter
+        ActiveRecord::Base.configurations[env]["adapter"]
+      rescue # don't believe this should throw an exception in real-world as only called from #database_engine which checks to see if ActiveRecord::Base is defined.
         nil
       end
     end

--- a/lib/scout_apm/framework_integrations/rails_3_or_4.rb
+++ b/lib/scout_apm/framework_integrations/rails_3_or_4.rb
@@ -54,7 +54,7 @@ module ScoutApm
 
       def get_database_adapter
         ActiveRecord::Base.configurations[env]["adapter"]
-      rescue # don't believe this should throw an exception in real-world as only called from #database_engine which checks to see if ActiveRecord::Base is defined.
+      rescue # this would throw an exception if ActiveRecord::Base is defined but no configuration exists.
         nil
       end
     end

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,4 +1,4 @@
 module ScoutApm
-  VERSION = "1.2.8.pre1"
+  VERSION = "1.2.9.pre"
 end
 

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,4 +1,4 @@
 module ScoutApm
-  VERSION = "1.2.9.pre"
+  VERSION = "1.2.9"
 end
 


### PR DESCRIPTION
This is done to address a weird edge case: the textacular gem overwrites `ActiveRecord::Base#respond_to?` and establishes an AR connection. 

This was unexpected and resulted in our threads creating many Postgres connections. The updated code uses a universal way to access the AR adapter (and is less code). We assume other gems are less likely to overwrite `ActiveRecord::Base.configurations`.

Bumps version to 1.2.9.pre.