### PR TITLE
Summary metrics for middleware logging issues

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,7 @@
 * If monitoring isn't enabled:
   * Don't install ScoutApm::Middleware
   * Don't start background worker
+* Preventing infinte loop (and app crash on startup) if the config file is malformed.
 
 # 1.2.10
 

--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -28,6 +28,8 @@ module ScoutApm
     # want to start the worker thread or install instrumentation if (1) disabled for this environment (2) a worker thread shouldn't
     # be started (when forking).
     def initialize(options = {})
+      # To start, we log to STDOUT. Once the agent is started, we use the logging settings provided in the config file. This ensures we always have a logger available.
+      @logger = Logger.new(STDOUT)
       @started = false
       @options ||= options
       @config = ScoutApm::Config.new(options[:config_path])

--- a/lib/scout_apm/agent/logging.rb
+++ b/lib/scout_apm/agent/logging.rb
@@ -13,7 +13,7 @@ module ScoutApm
         end
 
         begin
-          @logger ||= Logger.new(@log_file)
+          @logger = Logger.new(@log_file)
           @logger.level = log_level
           apply_log_format
         rescue Exception => e

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -50,10 +50,6 @@ module ScoutApm
       value.to_s.strip.length.zero? ? nil : value
     end
 
-    def load_error?
-      @load_error
-    end
-
     private
 
     def config_path

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -50,6 +50,10 @@ module ScoutApm
       value.to_s.strip.length.zero? ? nil : value
     end
 
+    def load_error?
+      @load_error
+    end
+
     private
 
     def config_path
@@ -74,16 +78,28 @@ module ScoutApm
 
     def load_file
       settings_hash = {}
-      begin
-        if File.exist?(config_file)
-          settings_hash = YAML.load(ERB.new(File.read(config_file)).result(binding))[config_environment] || {}
-        else
-          logger.warn "No config file found at [#{config_file}]."
+      # only attempt to load the file if a load error hasn't already occured. otherwise, an infinite loop can result when we try to apply the hostname to the 
+      # log formatter, which accesses this file.
+      if !@load_error
+        begin
+          if File.exist?(config_file)
+            erb = ERB.new(File.read(config_file)).result(binding)
+            yaml = YAML.load(erb)
+            settings_hash = if !yaml
+              logger.warn "The config file is not valid YAML and could not be read. Please check the file formatting:\n#{File.read(config_file)}"
+              {}
+            else
+              yaml[config_environment] || {}
+            end
+          else
+            logger.warn "No config file found at [#{config_file}]."
+          end
+        rescue Exception => e
+          @load_error = true
+          logger.warn "Unable to load the config file."
+          logger.warn e.message
+          logger.warn e.backtrace
         end
-      rescue Exception => e
-        logger.warn "Unable to load the config file."
-        logger.warn e.message
-        logger.warn e.backtrace
       end
       DEFAULTS.merge(settings_hash)
     end

--- a/test/data/bad_config.yml
+++ b/test/data/bad_config.yml
@@ -1,0 +1,2 @@
+# A bad config file that will result in an error when loaded (invalid ERB syntax below)
+<%=

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ end
 # Helpers available to all tests
 class Minitest::Test
   def setup
-    # reopen_logger
+    reopen_logger
     FileUtils.mkdir_p(DATA_FILE_DIR)
     ENV['SCOUT_DATA_FILE'] = DATA_FILE_PATH
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,14 +18,15 @@ end
 # Helpers available to all tests
 class Minitest::Test
   def setup
-    reopen_logger
+    # reopen_logger
     FileUtils.mkdir_p(DATA_FILE_DIR)
     ENV['SCOUT_DATA_FILE'] = DATA_FILE_PATH
   end
 
   def teardown
-    ScoutApm::Agent.instance.shutdown
+    ScoutApm::Agent.instance.shutdown if ScoutApm::Agent.instance.started?
     File.delete(DATA_FILE_PATH) if File.exist?(DATA_FILE_PATH)
+    ScoutApm::Agent.class_variable_set("@@instance",nil)
   end
 
   def set_rack_env(env)

--- a/test/unit/agent_test.rb
+++ b/test/unit/agent_test.rb
@@ -8,6 +8,19 @@ require 'scout_apm/store'
 
 class AgentTest < Minitest::Test
 
+  # Ensure a bad config file doesn't prevent the agent from starting.
+  def test_start_with_bad_config
+    ScoutApm::Agent.class_variable_set("@@instance",nil) # need to reset this so we're ready with a new agent
+    agent = ScoutApm::Agent.instance(:config_path => File.expand_path("../../data/bad_config.yml", __FILE__))
+    no_error = true
+    begin
+      agent.start
+    rescue Exception => e
+      no_error = false
+    end
+    assert no_error, "Error starting agent w/bad config file: #{e.message if e}"
+  end
+
   # Safeguard to ensure the main agent thread doesn't have any interaction with the layaway file. Contention on file locks can cause delays.
   def test_start_with_lock_on_layaway_file
     # setup the file, putting a lock on it.

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -26,5 +26,18 @@ class ConfigTest < Minitest::Test
     assert_equal "debug", conf.value('log_level')
     assert_equal "APM Test Conf (Production)", conf.value('name')
   end
+
+  # Ensure a bad config file doesn't cause an exception when accessing a config value
+  def test_config_value_with_bad_config
+    ScoutApm::Agent.class_variable_set("@@instance",nil) # need to reset this so we're ready with a new agent
+    agent = ScoutApm::Agent.instance(:config_path => File.expand_path("../../data/bad_config.yml", __FILE__))
+    no_error = true
+    begin
+      agent.config.value('monitor')
+    rescue Exception => e
+      no_error = false
+    end
+    assert no_error, "Error fetching config value w/bad config file: #{e.message if e}"
+  end
 end
 


### PR DESCRIPTION
Previously, if the agent was started w/a malformed config file the app would crash on startup due to an infinite loop trying to apply the hostname to the log formatter. Now, this won't occur. Additionally:

* The errors logged w/malformed config files are more specific
* The agent is initialized with a logger set to STDOUT, ensuring a logger is always available. On Agent#start, the logger is configured w/the scout_apm.yml settings and formatting is applied.

Some logging examples:

## Normal Startup

Nothing special appears.

## Bad YAML (wrong indentation)

<pre>
=> Booting WEBrick
=> Rails 4.2.5 application starting in development on http://localhost:4000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
W, [2016-01-25T12:22:33.164012 #87452]  WARN -- : Unable to load the config file.
W, [2016-01-25T12:22:33.164070 #87452]  WARN -- : (<unknown>): did not find expected key while parsing a block mapping at line 34 column 3
W, [2016-01-25T12:22:33.164172 #87452]  WARN -- : ["/Users/dlite/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/psych.rb:370:in `parse'", "/Users/dlite/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/psych.rb:370:in `parse_stream'", "/Users/dlite/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/psych.rb:318:in `parse'", "/Users/dlite/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/psych.rb:245:in `load'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:83:in `load_file'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:68:in `settings'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:64:in `setting'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:47:in `value'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/agent.rb:52:in `apm_enabled?'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm.rb:122:in `block in <class:Railtie>'", "/Users/dlite/.rvm/gems/ruby-2.2.0/gems/railties-4.2.5/lib/rails/initializable.rb:30:in `instance_exec'", "/Users/
</pre>

## Bad ERB

<pre>
=> Booting WEBrick
=> Rails 4.2.5 application starting in development on http://localhost:4000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
W, [2016-01-25T12:28:29.773563 #87685]  WARN -- : Unable to load the config file.
W, [2016-01-25T12:28:29.773641 #87685]  WARN -- : undefined local variable or method `hey' for #<ScoutApm::Config:0x007fa1f2adeee0>
W, [2016-01-25T12:28:29.773658 #87685]  WARN -- : ["(erb):31:in `load_file'", "/Users/dlite/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/erb.rb:863:in `eval'", "/Users/dlite/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/erb.rb:863:in `result'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:82:in `load_file'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:68:in `settings'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:64:in `setting'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/config.rb:47:in `value'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm/agent.rb:52:in `apm_enabled?'", "/Users/dlite/projects/scout_apm_ruby/lib/scout_apm.rb:12
</pre>


