### PR TITLE
Lazy sanitization of SQL, and a couple of performance improvements

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,10 @@
+# 1.2.12
+
+* SQL Sanitation-Related performance improvements:
+  * Lazy sanitation of SQL queries: only running when needed (a slow transaction is recorded)
+  * An SQL sanitation performance improvement (strip! vs. gsub!)
+  * Removing the TRAILING_SPACES regex - not used across all db engines and adds a bit more overhead
+
 # 1.2.11
 
 * Summarizing middleware instrumentation into a single metric for lower overhead.

--- a/lib/scout_apm/framework_integrations/rails_3_or_4.rb
+++ b/lib/scout_apm/framework_integrations/rails_3_or_4.rb
@@ -33,9 +33,10 @@ module ScoutApm
       end
 
       def database_engine
+        return @database_engine if @database_engine
         default = :mysql
 
-        if defined?(ActiveRecord::Base)
+        @database_engine = if defined?(ActiveRecord::Base)
           adapter = get_database_adapter # can be nil
 
           case adapter.to_s

--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -60,7 +60,7 @@ module ScoutApm
         sql, name = args
         self.class.instrument("ActiveRecord",
                               Utils::ActiveRecordMetricName.new(sql, name).metric_name,
-                              :desc => Utils::SqlSanitizer.new(sql).to_s ) do
+                              :desc => Utils::SqlSanitizer.new(sql) ) do
           log_without_scout_instruments(sql, name, &block)
         end
       end

--- a/lib/scout_apm/layer_converter.rb
+++ b/lib/scout_apm/layer_converter.rb
@@ -24,7 +24,6 @@ module ScoutApm
         end
       end
     end
-
   end
 
   # Take a TrackedRequest and turn it into a hash of:
@@ -54,8 +53,6 @@ module ScoutApm
                        else
                          {:scope => scope_layer.legacy_metric_name}
                        end
-
-        meta_options.merge!(:desc => layer.desc) if layer.desc
 
         meta = MetricMeta.new(layer.legacy_metric_name, meta_options)
         metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )
@@ -159,7 +156,7 @@ module ScoutApm
                        end
 
         # Specific Metric
-        meta_options.merge!(:desc => layer.desc) if layer.desc
+        meta_options.merge!(:desc => layer.desc.to_s) if layer.desc
         meta = MetricMeta.new(layer.legacy_metric_name, meta_options)
         meta.extra.merge!(:backtrace => ScoutApm::SlowTransaction.backtrace_parser(layer.backtrace)) if layer.backtrace
         metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )

--- a/lib/scout_apm/utils/sql_sanitizer.rb
+++ b/lib/scout_apm/utils/sql_sanitizer.rb
@@ -40,7 +40,7 @@ module ScoutApm
         sql.gsub!(PSQL_REMOVE_INTEGERS, '?')
         sql.gsub!(PSQL_IN_CLAUSE, 'IN (?)')
         sql.gsub!(MULTIPLE_SPACES, ' ')
-        sql.gsub!(TRAILING_SPACES, '')
+        sql.strip!
         sql
       end
 
@@ -51,7 +51,7 @@ module ScoutApm
         sql.gsub!(MYSQL_REMOVE_INTEGERS, '?')
         sql.gsub!(MYSQL_IN_CLAUSE, '?')
         sql.gsub!(MULTIPLE_QUESTIONS, '?')
-        sql.gsub!(TRAILING_SPACES, '')
+        sql.strip!
         sql
       end
 
@@ -60,7 +60,8 @@ module ScoutApm
         sql.gsub!(SQLITE_REMOVE_STRINGS, '?')
         sql.gsub!(SQLITE_REMOVE_INTEGERS, '?')
         sql.gsub!(MULTIPLE_SPACES, ' ')
-        sql.gsub!(TRAILING_SPACES, '')
+        sql.strip!
+        sql
       end
 
       def has_encodings?(encodings=['UTF-8', 'binary'])

--- a/lib/scout_apm/utils/sql_sanitizer.rb
+++ b/lib/scout_apm/utils/sql_sanitizer.rb
@@ -12,12 +12,15 @@ module ScoutApm
       end
       include ScoutApm::Utils::SqlRegex
 
-      attr_reader :sql
       attr_accessor :database_engine
 
       def initialize(sql)
-        @sql = scrubbed(sql.dup)
+        @raw_sql = sql
         @database_engine = ScoutApm::Environment.instance.database_engine
+      end
+
+      def sql
+        @sql ||= scrubbed(@raw_sql.dup) # don't do this in initialize as it is extra work that isn't needed unless we have a slow transaction.
       end
 
       def to_s

--- a/lib/scout_apm/utils/sql_sanitizer_regex.rb
+++ b/lib/scout_apm/utils/sql_sanitizer_regex.rb
@@ -4,7 +4,6 @@ module ScoutApm
     module SqlRegex
       MULTIPLE_SPACES    = %r|\s+|.freeze
       MULTIPLE_QUESTIONS = /\?(,\?)+/.freeze
-      TRAILING_SPACES    = /\s+$/.freeze
 
       PSQL_VAR_INTERPOLATION = %r|\[\[.*\]\]\s*$|.freeze
       PSQL_REMOVE_STRINGS = /'(?:[^']|'')*'/.freeze

--- a/lib/scout_apm/utils/sql_sanitizer_regex_1_8_7.rb
+++ b/lib/scout_apm/utils/sql_sanitizer_regex_1_8_7.rb
@@ -4,7 +4,6 @@ module ScoutApm
     module SqlRegex
       MULTIPLE_SPACES    = %r|\s+|.freeze
       MULTIPLE_QUESTIONS = /\?(,\?)+/.freeze
-      TRAILING_SPACES    = /\s+$/.freeze
 
       PSQL_VAR_INTERPOLATION = %r|\[\[.*\]\]\s*$|.freeze
       PSQL_REMOVE_STRINGS = /'(?:[^']|'')*'/.freeze

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,4 +1,4 @@
 module ScoutApm
-  VERSION = "1.2.11"
+  VERSION = "1.2.12"
 end
 


### PR DESCRIPTION
Previously, we were sanitizing SQL queries as layers were added. Now, we sanitize only where it is needed: `LayerSlowTransactionConverter`. This results in large performance gains:

* overhead benchmarks drop from 8.1% to 3.2%
* stackprof samples for `ScoutApm::Utils::SqlSanitizer#to_s_postgres` drop from 1.2% to 0%

This also addresses a couple other higher-sample % numbers from stackprof output:

* Memo-izing fetching the database driver
* Using strip! vs. gsub!

This needs to run on production environments first before merging. 