### PR TITLE
uri reporting config option (path or fullpath)

### DIFF
--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -13,6 +13,7 @@ require 'scout_apm/environment'
 # log_level        - DEBUG / INFO / WARN as usual
 # monitor          - true or false.  False prevents any instrumentation from starting
 # name             - override the name reported to APM. This is the name that shows in the Web UI
+# uri_reporting    - 'path' or 'full_path' default is 'full_path', which reports URL params as well as the path.
 #
 # Any of these config settings can be set with an environment variable prefixed
 # by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
@@ -22,7 +23,8 @@ module ScoutApm
     DEFAULTS =  {
         'host'      => 'https://checkin.scoutapp.com',
         'log_level' => 'info',
-        'stackprof_interval' => 20000 # microseconds, 1000 = 1 millisecond, so 20k == 20 milliseconds
+        'stackprof_interval' => 20000, # microseconds, 1000 = 1 millisecond, so 20k == 20 milliseconds
+        'uri_reporting' => 'full_path'
     }.freeze
 
     def initialize(config_path = nil)

--- a/lib/scout_apm/instruments/action_controller_rails_2.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_2.rb
@@ -58,7 +58,8 @@ module ScoutApm
       # specific controller actions.
       def perform_action_with_scout_instruments(*args, &block)
         req = ScoutApm::RequestManager.lookup
-        req.annotate_request(:uri => request.fullpath)
+        path = ScoutApm::Agent.instance.config.value("uri_reporting") == 'path' ? request.path : request.fullpath
+        req.annotate_request(:uri => path)
         req.context.add_user(:ip => request.remote_ip)
         req.set_headers(request.headers)
         req.start_layer( ScoutApm::Layer.new("Controller", "#{controller_path}/#{action_name}") )

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -59,7 +59,8 @@ module ScoutApm
     module ActionControllerRails3Rails4Instruments
       def process_action(*args)
         req = ScoutApm::RequestManager.lookup
-        req.annotate_request(:uri => request.fullpath)
+        path = ScoutApm::Agent.instance.config.value("uri_reporting") == 'path' ? request.path : request.fullpath
+        req.annotate_request(:uri => path)
         req.context.add_user(:ip => request.remote_ip)
         req.set_headers(request.headers)
 


### PR DESCRIPTION
For customers that don't want URL params propagated into Scout. Default is fullpath.