### PR TITLE
Storing scoped object allocation metrics

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -33,6 +33,7 @@ require 'scout_apm/tracked_request'
 require 'scout_apm/layer'
 require 'scout_apm/request_manager'
 require 'scout_apm/layer_converter'
+require 'scout_apm/layer_converters/object_allocation'
 require 'scout_apm/request_queue_time'
 
 require 'scout_apm/server_integrations/passenger'

--- a/lib/scout_apm/layer_converter.rb
+++ b/lib/scout_apm/layer_converter.rb
@@ -55,7 +55,7 @@ module ScoutApm
                        end
 
         # we don't need to use the full metric name for scoped metrics as we only display metrics aggregrated
-        # by type.
+        # by type (ex: all ActiveRecord calls under a controller are grouped together).
         metric_name = meta_options.has_key?(:scope) ? layer.type : layer.legacy_metric_name
 
         meta = MetricMeta.new(metric_name, meta_options)
@@ -171,23 +171,6 @@ module ScoutApm
       end
 
       metric_hash
-    end
-  end
-
-  class LayerObjectAllocationsConverter < LayerConverterBase
-    def call
-      scope = scope_layer
-
-      return {} unless scope
-
-      meta = MetricMeta.new("ObjectAllocations/#{scope.legacy_metric_name}")
-      stat = MetricStats.new
-
-      walker.walk do |layer|
-        stat.update!(layer.object_allocations)
-      end
-
-      { meta => stat }
     end
   end
 

--- a/lib/scout_apm/layer_converters/object_allocation.rb
+++ b/lib/scout_apm/layer_converters/object_allocation.rb
@@ -1,0 +1,41 @@
+module ScoutApm
+  module LayerConverters
+    # Object Allocation metrics for this request. These have the same format as timing metrics - only aggregrates of 
+    # the layer#type are stored.
+    class ObjectAllocation < LayerConverterBase
+      PREFIX = "ObjectAllocations/".freeze
+      def call
+        scope = scope_layer
+
+        return {} unless scope
+
+        create_metrics
+      end
+
+      # Almost the same as +LayerMetricConverter#create_metrics+. Differences:
+      # * prefix metric_name w/ "ObjectAllocations/"
+      # * update stats w/ +layer.object_allocations+ vs. call times.
+      def create_metrics
+        metric_hash = Hash.new
+
+        walker.walk do |layer|
+          meta_options = if layer == scope_layer # We don't scope the controller under itself
+                           {}
+                         else
+                           {:scope => PREFIX+scope_layer.legacy_metric_name}
+                         end
+
+          metric_name = meta_options.has_key?(:scope) ? layer.type : PREFIX+layer.legacy_metric_name
+
+          meta = MetricMeta.new(metric_name, meta_options)
+          metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )
+
+          stat = metric_hash[meta]
+          # calling state#update! and passing in allocations as time makes server-side metric queries involved. this is handled easier.
+          stat.call_count += layer.object_allocations 
+        end
+        metric_hash
+      end
+    end
+  end
+end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -143,7 +143,7 @@ module ScoutApm
       queue_time_metrics = RequestQueueTime.new(self).call
       ScoutApm::Agent.instance.store.track!(queue_time_metrics)
 
-      object_allocation_metrics = LayerObjectAllocationsConverter.new(self).call
+      object_allocation_metrics = LayerConverters::ObjectAllocation.new(self).call
       ScoutApm::Agent.instance.store.track!(object_allocation_metrics)
 
       # ScoutApm::Agent.instance.logger.debug("Finished recording request") if metrics.any?

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,4 +1,4 @@
 module ScoutApm
-  VERSION = "1.5.0.pre"
+  VERSION = "1.5.0.pre1"
 end
 


### PR DESCRIPTION
Previously, allocation metrics were only stored at the controller-level. Now, they are scoped under the controller (just like timing metrics). Also:

* Start of some refactoring to move LayerConverters into separate files.
* Passing the object allocation count via call_count vs. updating timing (messes with server-side things).