### PR TITLE
Fixing allocating objects to parent layers

### DIFF
--- a/ext/stack_profile/stack_profile.c
+++ b/ext/stack_profile/stack_profile.c
@@ -124,9 +124,7 @@ void increment_allocations() {
 
 static VALUE
 get_allocation_count() {
-  uint64_t ret = endpoint_allocations;
-  endpoint_allocations = 0;
-  return ULL2NUM(ret);
+  return ULL2NUM(endpoint_allocations);
 }
 
 void Init_stack_profile()

--- a/lib/scout_apm/layer_converters/object_allocation.rb
+++ b/lib/scout_apm/layer_converters/object_allocation.rb
@@ -32,7 +32,7 @@ module ScoutApm
 
           stat = metric_hash[meta]
           # calling state#update! and passing in allocations as time makes server-side metric queries involved. this is handled easier.
-          stat.call_count += layer.object_allocations 
+          stat.call_count += layer.total_exclusive_objects 
         end
         metric_hash
       end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -52,7 +52,7 @@ module ScoutApm
       layer = @layers.pop
       layer.record_stop_time!
       #@gc_generations += layer.record_gc_data(@gc_generations) # don't find any gc events that are in the array of gc generation ids
-      layer.record_object_allocations
+      layer.record_objects!
 
       # Do this here, rather than in the layer because we need this caller. Maybe able to move it?
       if layer.total_exclusive_time > ScoutApm::SlowTransaction::BACKTRACE_THRESHOLD


### PR DESCRIPTION
We reset the allocation count when we record it when a layer is completed. This means that allocations that occur between the start of a parent layer (ex: Controller) and a child layer (ex: ActiveRecord) are attributed entirely to the child.

This fixes the issue - it mirrors how we calculate timing numbers closely.