### PR TITLE
Added MetricMeta#kind attribute to support objects

### DIFF
--- a/lib/scout_apm/layer_converters/object_allocation.rb
+++ b/lib/scout_apm/layer_converters/object_allocation.rb
@@ -3,7 +3,6 @@ module ScoutApm
     # Object Allocation metrics for this request. These have the same format as timing metrics - only aggregrates of 
     # the layer#type are stored.
     class ObjectAllocation < LayerConverterBase
-      PREFIX = "ObjectAllocations/".freeze
       def call
         scope = scope_layer
 
@@ -13,8 +12,7 @@ module ScoutApm
       end
 
       # Almost the same as +LayerMetricConverter#create_metrics+. Differences:
-      # * prefix metric_name w/ "ObjectAllocations/"
-      # * update stats w/ +layer.object_allocations+ vs. call times.
+      # * set meta.kind = 'object'
       def create_metrics
         metric_hash = Hash.new
 
@@ -22,10 +20,11 @@ module ScoutApm
           meta_options = if layer == scope_layer # We don't scope the controller under itself
                            {}
                          else
-                           {:scope => PREFIX+scope_layer.legacy_metric_name}
+                           {:scope => scope_layer.legacy_metric_name}
                          end
+          meta_options[:kind] = 'object'
 
-          metric_name = meta_options.has_key?(:scope) ? PREFIX+layer.type : PREFIX+layer.legacy_metric_name
+          metric_name = meta_options.has_key?(:scope) ? layer.type : layer.legacy_metric_name
 
           meta = MetricMeta.new(metric_name, meta_options)
           metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )

--- a/lib/scout_apm/metric_meta.rb
+++ b/lib/scout_apm/metric_meta.rb
@@ -8,12 +8,13 @@ class MetricMeta
     @metric_id = nil
     @scope = options[:scope]
     @desc = options[:desc]
+    @kind = options[:kind] # added in 1.5.0. options: nil | 'object'.
     @extra = {}
   end
   attr_accessor :metric_id, :metric_name
   attr_accessor :scope
   attr_accessor :client_id
-  attr_accessor :desc, :extra
+  attr_accessor :desc, :extra, :kind
 
   # Unsure if type or bucket is a better name.
   def type
@@ -31,7 +32,7 @@ class MetricMeta
 
   # To avoid conflicts with different JSON libaries
   def to_json(*a)
-     %Q[{"metric_id":#{metric_id || 'null'},"metric_name":#{metric_name.to_json},"scope":#{scope.to_json || 'null'}}]
+     %Q[{"metric_id":#{metric_id || 'null'},"metric_name":#{metric_name.to_json},"scope":#{scope.to_json || 'null'},"kind":#{kind.to_json || 'null'}}]
   end
 
   def ==(o)
@@ -42,6 +43,7 @@ class MetricMeta
     h = metric_name.downcase.hash
     h ^= scope.downcase.hash unless scope.nil?
     h ^= desc.downcase.hash unless desc.nil?
+    h ^= kind.downcase.hash unless kind.nil?
     h
   end
 
@@ -49,12 +51,13 @@ class MetricMeta
    self.class             == o.class                &&
      metric_name.downcase == o.metric_name.downcase &&
      scope                == o.scope                &&
+     kind                 == o.kind                 &&
      client_id            == o.client_id            &&
      desc                 == o.desc
   end
 
   def as_json
-    json_attributes = [:bucket, :name, :desc, :extra, [:scope, :scope_hash]]
+    json_attributes = [:bucket, :name, :kind, :desc, :extra, [:scope, :scope_hash]]
     # query, stack_trace
     ScoutApm::AttributeArranger.call(self, json_attributes)
   end

--- a/lib/scout_apm/store.rb
+++ b/lib/scout_apm/store.rb
@@ -165,15 +165,8 @@ module ScoutApm
         @aggregate_metrics[agg_meta] ||= MetricStats.new
         @aggregate_metrics[agg_meta].combine!(stat)
 
-      elsif meta.type == "ObjectAllocations"
-        @aggregate_metrics[meta] ||= MetricStats.new
-        @aggregate_metrics[meta].combine!(stat)
-        agg_meta = MetricMeta.new("ObjectAllocations/all", :scope => meta.scope)
-        @aggregate_metrics[agg_meta] ||= MetricStats.new
-        @aggregate_metrics[agg_meta].combine!(stat)
-
-      else # Combine down to a single /all key
-        agg_meta = MetricMeta.new("#{meta.type}/all", :scope => meta.scope)
+      else # Combine down to a single /all key (objects and plain-old metrics)
+        agg_meta = MetricMeta.new("#{meta.type}/all", :scope => meta.scope, :kind => meta.kind)
         @aggregate_metrics[agg_meta] ||= MetricStats.new
         @aggregate_metrics[agg_meta].combine!(stat)
       end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -143,8 +143,8 @@ module ScoutApm
       queue_time_metrics = RequestQueueTime.new(self).call
       ScoutApm::Agent.instance.store.track!(queue_time_metrics)
 
-      object_allocation_metrics = LayerConverters::ObjectAllocation.new(self).call
-      ScoutApm::Agent.instance.store.track!(object_allocation_metrics)
+      object_metrics = LayerConverters::ObjectAllocation.new(self).call
+      ScoutApm::Agent.instance.store.track!(object_metrics)
 
       # ScoutApm::Agent.instance.logger.debug("Finished recording request") if metrics.any?
     end

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,4 +1,4 @@
 module ScoutApm
-  VERSION = "1.5.0.pre1"
+  VERSION = "1.5.0.pre3"
 end
 


### PR DESCRIPTION
This adds a `MetricMeta#kind` attribute, which is used to identify object allocation metrics. 

kind = "objects" || nil.

Requires a sever-side change.