### PR TITLE
Background jobs n+1 w/CallSet

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# 1.5.1
+
+* Collecting backtraces on n+1 calls
+
 # 1.4.5
 
 * Instrument Elasticsearch

--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -88,6 +88,7 @@ require 'scout_apm/instruments/process/process_memory'
 require 'scout_apm/app_server_load'
 
 require 'scout_apm/utils/sql_sanitizer'
+require 'scout_apm/utils/backtrace_parser'
 require 'scout_apm/utils/active_record_metric_name'
 require 'scout_apm/utils/null_logger'
 require 'scout_apm/utils/installed_gems'

--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -32,6 +32,7 @@ require 'scout_apm/version'
 require 'scout_apm/tracked_request'
 require 'scout_apm/layer'
 require 'scout_apm/request_manager'
+require 'scout_apm/call_set'
 
 require 'scout_apm/layer_converters/converter_base'
 require 'scout_apm/layer_converters/depth_first_walker'

--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -39,7 +39,7 @@ require 'scout_apm/layer_converters/error_converter'
 require 'scout_apm/layer_converters/job_converter'
 require 'scout_apm/layer_converters/slow_job_converter'
 require 'scout_apm/layer_converters/metric_converter'
-require 'scout_apm/layer_converters/slow_transaction_converter'
+require 'scout_apm/layer_converters/slow_request_converter'
 require 'scout_apm/layer_converters/request_queue_time_converter'
 
 require 'scout_apm/server_integrations/passenger'

--- a/lib/scout_apm/call_set.rb
+++ b/lib/scout_apm/call_set.rb
@@ -1,67 +1,49 @@
 module ScoutApm
   class CallSet
-    include Enumerable
 
-    N_PLUS_ONE_MAGIC_NUMBER = 5 # Fetch backtraces on this number of calls to a layer. The caller data is only collected on this call (and this + greater) to limit overhead.
+    N_PLUS_ONE_MAGIC_NUMBER = 5 # Fetch backtraces on this number of calls to a layer. The caller data is only collected on this call to limit overhead.
 
     attr_reader :call_count
 
     def initialize
-      @items = []
-      @grouped_items = Hash.new { |h, k| h[k] = [] }
+      @items = [] # An array of Layer descriptions that are associated w/a single Layer name (ex: User/find). Note this may contain nil items.
+      @grouped_items = Hash.new { |h, k| h[k] = [] } # items groups by their normalized name since multiple layers could have the same layer name.
       @call_count = 0
       @captured = false
     end
 
-    def each
-      @items.each { |s| yield s }
-    end
-
     def update!(item = nil)
       if @captured # No need to do any work if we've already captured a backtrace.
-        ScoutApm::Agent.instance.logger.debug { "Already captured a backtrace for item [#{item}]" }
         return
       end
       @call_count += 1
-      if item
-        @items << item
-        if @grouped_items.any? # lazy grouping as normalizing items can be expensive.
-          @grouped_items[unique_name_for(item)] << item
-        end
+      @items << item
+      if @grouped_items.any? # lazy grouping as normalizing items can be expensive.
+        @grouped_items[unique_name_for(item)] << item
       end
     end
 
     # We're selective on capturing a backtrace for two reasons:
     # * Grouping ActiveRecord calls requires us to sanitize the SQL. This isn't cheap.
     # * Capturing backtraces isn't cheap.
-    # TODO - this doesn't handle a case of some nil items and some non-nil items.
     def capture_backtrace?
-      #binding.pry if !@captured && @call_count >= N_PLUS_ONE_MAGIC_NUMBER
-      if !@captured && @call_count >= N_PLUS_ONE_MAGIC_NUMBER &&
-          ( 
-            (!grouping? && @call_count == N_PLUS_ONE_MAGIC_NUMBER ) || # items is empty if the layer doesn't have a description (ex: ActionView). there's no aggregration required here.
-            grouped_at_magic_number?
-          )
+      if !@captured && @call_count >= N_PLUS_ONE_MAGIC_NUMBER && at_magic_number?
         @captured = true
       end
     end
 
-    def grouping?
-      !@items.empty?
-    end
-
-    def grouped_at_magic_number?
+    def at_magic_number?
       res=grouped_items[unique_name_for(@items.last)].size == N_PLUS_ONE_MAGIC_NUMBER
       if res
         ScoutApm::Agent.instance.logger.debug "Grouped Call Set @ magic number."
       end
+      res
     end
 
     def grouped_items
       if @grouped_items.any? 
         @grouped_items
       else
-        ScoutApm::Agent.instance.logger.debug { "Grouping items: #{@items.last}" }
         @grouped_items.merge!(@items.group_by { |item| unique_name_for(item) })
       end
     end

--- a/lib/scout_apm/call_set.rb
+++ b/lib/scout_apm/call_set.rb
@@ -42,7 +42,7 @@ module ScoutApm
     end
 
     def at_magic_number?
-      res=grouped_items[unique_name_for(@items.last)].size == N_PLUS_ONE_MAGIC_NUMBER
+      res=grouped_items[unique_name_for(@items.last)].size >= N_PLUS_ONE_MAGIC_NUMBER
       if res
         ScoutApm::Agent.instance.logger.debug "Grouped Call Set @ magic number."
       end

--- a/lib/scout_apm/call_set.rb
+++ b/lib/scout_apm/call_set.rb
@@ -1,0 +1,73 @@
+module ScoutApm
+  class CallSet
+    include Enumerable
+
+    N_PLUS_ONE_MAGIC_NUMBER = 5 # Fetch backtraces on this number of calls to a layer. The caller data is only collected on this call (and this + greater) to limit overhead.
+
+    attr_reader :call_count
+
+    def initialize
+      @items = []
+      @grouped_items = Hash.new { |h, k| h[k] = [] }
+      @call_count = 0
+      @captured = false
+    end
+
+    def each
+      @items.each { |s| yield s }
+    end
+
+    def update!(item = nil)
+      if @captured # No need to do any work if we've already captured a backtrace.
+        ScoutApm::Agent.instance.logger.debug "Already captured a backtrace for item [#{item}]"
+        return
+      end
+      @call_count += 1
+      if item
+        @items << item
+        if @grouped_items.any? # lazy grouping as normalizing items can be expensive.
+          @grouped_items[unique_name_for(item)] << item
+        end
+      end
+    end
+
+    # We're selective on capturing a backtrace for two reasons:
+    # * Grouping ActiveRecord calls requires us to sanitize the SQL. This isn't cheap.
+    # * Capturing backtraces isn't cheap.
+    # TODO - this doesn't handle a case of some nil items and some non-nil items.
+    def capture_backtrace?
+      #binding.pry if !@captured && @call_count >= N_PLUS_ONE_MAGIC_NUMBER
+      if !@captured && @call_count >= N_PLUS_ONE_MAGIC_NUMBER &&
+          ( 
+            (!grouping? && @call_count == N_PLUS_ONE_MAGIC_NUMBER ) || # items is empty if the layer doesn't have a description (ex: ActionView). there's no aggregration required here.
+            grouped_at_magic_number?
+          )
+        @captured = true
+      end
+    end
+
+    def grouping?
+      !@items.empty?
+    end
+
+    def grouped_at_magic_number?
+      res=grouped_items[unique_name_for(@items.last)].size == N_PLUS_ONE_MAGIC_NUMBER
+      if res
+        ScoutApm::Agent.instance.logger.debug "Grouped Call Set @ magic number."
+      end
+    end
+
+    def grouped_items
+      if @grouped_items.any? 
+        @grouped_items
+      else
+        @items.group_by { |item| unique_name_for(item) }
+      end
+    end
+
+    # Determine this items' "hash key"
+    def unique_name_for(item)
+      item.to_s
+    end
+  end
+end

--- a/lib/scout_apm/call_set.rb
+++ b/lib/scout_apm/call_set.rb
@@ -61,7 +61,7 @@ module ScoutApm
       if @grouped_items.any? 
         @grouped_items
       else
-        @items.group_by { |item| unique_name_for(item) }
+        @grouped_items = @items.group_by { |item| unique_name_for(item) }
       end
     end
 

--- a/lib/scout_apm/call_set.rb
+++ b/lib/scout_apm/call_set.rb
@@ -19,7 +19,7 @@ module ScoutApm
 
     def update!(item = nil)
       if @captured # No need to do any work if we've already captured a backtrace.
-        ScoutApm::Agent.instance.logger.debug "Already captured a backtrace for item [#{item}]"
+        ScoutApm::Agent.instance.logger.debug { "Already captured a backtrace for item [#{item}]" }
         return
       end
       @call_count += 1
@@ -61,7 +61,8 @@ module ScoutApm
       if @grouped_items.any? 
         @grouped_items
       else
-        @grouped_items = @items.group_by { |item| unique_name_for(item) }
+        ScoutApm::Agent.instance.logger.debug { "Grouping items: #{@items.last}" }
+        @grouped_items.merge!(@items.group_by { |item| unique_name_for(item) })
       end
     end
 

--- a/lib/scout_apm/call_set.rb
+++ b/lib/scout_apm/call_set.rb
@@ -2,7 +2,7 @@ module ScoutApm
   class CallSet
 
     N_PLUS_ONE_MAGIC_NUMBER = 5 # Fetch backtraces on this number of calls to a layer. The caller data is only collected on this call to limit overhead.
-    N_PLUS_ONE_TIME_THRESHOLD = 50/1000.0 # Minimum time in seconds before we start performing any work. This is to prevent doing a lot of work on already fast calls.
+    N_PLUS_ONE_TIME_THRESHOLD = 100/1000.0 # Minimum time in seconds before we start performing any work. This is to prevent doing a lot of work on already fast calls.
 
     attr_reader :call_count
 

--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -130,7 +130,11 @@ module ScoutApm
     end
 
     def background_job_integration
-      @background_job_integration ||= BACKGROUND_JOB_INTEGRATIONS.detect {|integration| integration.present?}
+      if Agent.instance.config.value("enable_background_jobs", !Agent.instance.config.config_file_exists?)
+        @background_job_integration ||= BACKGROUND_JOB_INTEGRATIONS.detect {|integration| integration.present?}
+      else
+        nil
+      end
     end
 
     def background_job_name

--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -160,11 +160,15 @@ module ScoutApm
     end
 
     def ruby_19?
-      defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION.match(/^1\.9/)
+      @ruby_19 ||= defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION.match(/^1\.9/)
     end
 
     def ruby_187?
-      defined?(RUBY_VERSION) && RUBY_VERSION.match(/^1\.8\.7/)
+      @ruby_187 ||= defined?(RUBY_VERSION) && RUBY_VERSION.match(/^1\.8\.7/)
+    end
+
+    def ruby_2?
+      @ruby_2 ||= defined?(RUBY_VERSION) && RUBY_VERSION.match(/^2/)
     end
 
     ### framework checks

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -68,7 +68,7 @@ module ScoutApm
     end
 
     def capture_backtrace!
-      ScoutApm::Agent.instance.logger.debug "Capturing Backtrace for Layer [#{type}/#{name}]"
+      ScoutApm::Agent.instance.logger.debug { "Capturing Backtrace for Layer [#{type}/#{name}]" }
       @backtrace = caller_array
     end
 

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -30,6 +30,7 @@ module ScoutApm
     # backtrace of where it occurred.
     attr_reader :backtrace
 
+    BACKTRACE_CALLER_LIMIT = 30 # maximum number of lines to send thru for backtrace analysis
 
     def initialize(type, name, start_time = Time.now)
       @type = type
@@ -74,9 +75,9 @@ module ScoutApm
     def caller_array
       # omits the first several callers which are in the ScoutAPM stack.
       if ScoutApm::Environment.instance.ruby_2?
-        caller(3...TrackedRequest::BACKTRACE_CALLER_LIMIT)
+        caller(3...BACKTRACE_CALLER_LIMIT)
       else
-        caller[3...TrackedRequest::BACKTRACE_CALLER_LIMIT]
+        caller[3...BACKTRACE_CALLER_LIMIT]
       end
     end
 

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -66,10 +66,18 @@ module ScoutApm
       "#{type}/#{name}"
     end
 
-    def store_backtrace(bt)
-      return unless bt.is_a? Array
-      return unless bt.length > 0
-      @backtrace = bt
+    def capture_backtrace!
+      @backtrace = caller_array
+    end
+
+    # In Ruby 2.0+, we can pass the range directly to the caller to reduce the memory footprint.
+    def caller_array
+      # omits the first several callers which are in the ScoutAPM stack.
+      if ScoutApm::Environment.instance.ruby_2?
+        caller(3...TrackedRequest::BACKTRACE_CALLER_LIMIT)
+      else
+        caller[3...TrackedRequest::BACKTRACE_CALLER_LIMIT]
+      end
     end
 
     ######################################

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -68,7 +68,7 @@ module ScoutApm
     end
 
     def capture_backtrace!
-      ScoutApm::Agent.instance.logger.debug "Captured Backtrace for Layer [#{type}/#{name}]"
+      ScoutApm::Agent.instance.logger.debug "Capturing Backtrace for Layer [#{type}/#{name}]"
       @backtrace = caller_array
     end
 

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -68,6 +68,7 @@ module ScoutApm
     end
 
     def capture_backtrace!
+      ScoutApm::Agent.instance.logger.debug "Captured Backtrace for Layer [#{type}/#{name}]"
       @backtrace = caller_array
     end
 

--- a/lib/scout_apm/layer_converters/slow_job_converter.rb
+++ b/lib/scout_apm/layer_converters/slow_job_converter.rb
@@ -69,7 +69,8 @@ module ScoutApm
           # Specific Metric
           meta_options.merge!(:desc => layer.desc.to_s) if layer.desc
           meta = MetricMeta.new(layer.legacy_metric_name, meta_options)
-          meta.extra.merge!(:backtrace => ScoutApm::SlowTransaction.backtrace_parser(layer.backtrace)) if layer.backtrace
+          # this has moved - commenting out for now. will copy over bits from SlowRequestConverter
+          # meta.extra.merge!(:backtrace => ScoutApm::SlowTransaction.backtrace_parser(layer.backtrace)) if layer.backtrace
           metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )
           stat = metric_hash[meta]
           stat.update!(layer.total_call_time, layer.total_exclusive_time)

--- a/lib/scout_apm/layer_converters/slow_request_converter.rb
+++ b/lib/scout_apm/layer_converters/slow_request_converter.rb
@@ -1,6 +1,6 @@
 module ScoutApm
   module LayerConverters
-    class SlowTransactionConverter < ConverterBase
+    class SlowRequestConverter < ConverterBase
       def call
         scope = scope_layer
         return [nil, {}] unless scope

--- a/lib/scout_apm/layer_converters/slow_request_converter.rb
+++ b/lib/scout_apm/layer_converters/slow_request_converter.rb
@@ -87,6 +87,8 @@ module ScoutApm
               # Why not just call meta.backtrace and call it done? The walker could access a later later that generates the same MetricMeta but doesn't have a backtrace. This could be
               # lost in the metric_hash if it is replaced by the new key.
               @backtraces << meta
+            else
+              ScoutApm::Agent.instance.logger.debug "Unable to capture an app-specific backtrace for #{meta.inspect}\n#{layer.backtrace}"
             end
           end
           metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )

--- a/lib/scout_apm/metric_meta.rb
+++ b/lib/scout_apm/metric_meta.rb
@@ -38,6 +38,15 @@ class MetricMeta
     self.eql?(o)
   end
 
+  # This should be abstracted to a true accessor ... earned it.
+  def backtrace=(bt)
+    extra[:backtrace] = bt
+  end
+
+  def backtrace
+    extra[:backtrace]
+  end
+
   def hash
     h = metric_name.downcase.hash
     h ^= scope.downcase.hash unless scope.nil?

--- a/lib/scout_apm/slow_transaction.rb
+++ b/lib/scout_apm/slow_transaction.rb
@@ -2,10 +2,6 @@ module ScoutApm
   class SlowTransaction
     include ScoutApm::BucketNameSplitter
 
-    BACKTRACE_THRESHOLD = 0.5 # the minimum threshold in seconds to record the backtrace for a metric.
-    BACKTRACE_LIMIT = 5 # Max length of callers to display
-    MAX_SIZE = 100 # Limits the size of the metric hash to prevent a metric explosion.
-
     attr_reader :metric_name
     attr_reader :total_call_time
     attr_reader :metrics
@@ -15,24 +11,6 @@ module ScoutApm
     attr_reader :time
     attr_reader :prof
     attr_reader :raw_prof
-
-    # TODO: Move this out of SlowTransaction, it doesn't have much to do w/
-    # slow trans other than being a piece of data that ends up in it.
-    #
-    # Given a call stack, generates a filtered backtrace that:
-    # * Limits to the app/models, app/controllers, or app/views directories
-    # * Limits to 5 total callers
-    # * Makes the app folder the top-level folder used in trace info
-    def self.backtrace_parser(backtrace)
-      stack = []
-      backtrace.each do |c|
-        if m=c.match(/(\/app\/(controllers|models|views)\/.+)/)
-          stack << m[1]
-          break if stack.size == BACKTRACE_LIMIT
-        end
-      end
-      stack
-    end
 
     def initialize(uri, metric_name, total_call_time, metrics, context, time, raw_stackprof)
       @uri = uri

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -41,7 +41,6 @@ module ScoutApm
 
     N_PLUS_ONE_MAGIC_NUMBER = 5 # Fetch backtraces on this number of calls to a layer.
     BACKTRACE_THRESHOLD = 0.5 # the minimum threshold in seconds to record the backtrace for a metric.
-    BACKTRACE_CALLER_LIMIT = 30 # maximum number of lines to send thru for backtrace analysis
 
     def initialize
       @layers = []

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -39,7 +39,7 @@ module ScoutApm
     # with same names across multiple types.
     attr_accessor :call_counts
 
-    N_PLUS_ONE_MAGIC_NUMBER = 5 # Fetch backtraces on this number of calls to a layer.
+    N_PLUS_ONE_MAGIC_NUMBER = 5 # Fetch backtraces on this number of calls to a layer. The caller data is only collected on this call (and this + greater) to limit overhead.
     BACKTRACE_THRESHOLD = 0.5 # the minimum threshold in seconds to record the backtrace for a metric.
 
     def initialize
@@ -81,8 +81,8 @@ module ScoutApm
     end
 
     def capture_backtrace?(layer)
-      layer.total_exclusive_time > BACKTRACE_THRESHOLD ||
-        @call_counts[layer.name] == N_PLUS_ONE_MAGIC_NUMBER
+      layer != root_layer && # don't collect a backtrace for the root layer as the backtrace doesn't reach into the Rails app folder.
+        (layer.total_exclusive_time > BACKTRACE_THRESHOLD || @call_counts[layer.name] == N_PLUS_ONE_MAGIC_NUMBER)
     end
 
     # Maintains a lookup Hash of call counts by layer name. Used to determine if we should capture a backtrace.

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -81,7 +81,7 @@ module ScoutApm
     end
 
     def capture_backtrace?(layer)
-      layer != root_layer && # don't collect a backtrace for the root layer as the backtrace doesn't reach into the Rails app folder.
+      layer.type != 'Controller' && # don't collect a backtrace for the Controller layer as the backtrace doesn't reach into the Rails app folder.
         (layer.total_exclusive_time > BACKTRACE_THRESHOLD || @call_counts[layer.name] == N_PLUS_ONE_MAGIC_NUMBER)
     end
 

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -176,7 +176,7 @@ module ScoutApm
       metrics = LayerConverters::MetricConverter.new(self).call
       ScoutApm::Agent.instance.store.track!(metrics)
 
-      slow, slow_metrics = LayerConverters::SlowTransactionConverter.new(self).call
+      slow, slow_metrics = LayerConverters::SlowRequestConverter.new(self).call
       ScoutApm::Agent.instance.store.track_slow_transaction!(slow)
       ScoutApm::Agent.instance.store.track!(slow_metrics)
 

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -27,16 +27,23 @@ module ScoutApm
         end
       end
 
-      # For the layer lookup. Doesn't look @ SQL as unsanitized SQL will likely be more prevalant. This will treat different SQL calls to the same model as the same.
+      # For the layer lookup.
       def hash
         h = name.downcase.hash
+        h ^= sanitized_sql.hash unless sanitized_sql.nil? # can't think of a case where this would be nil, but just in case...
         h
       end
 
-      # For the layer lookup. Doesn't look @ SQL as unsanitized SQL will likely be more prevalant. This will treat different SQL calls to the same model as the same.
+      # For the layer lookup.
+      # Reminder: #eql? is for Hash equality: returns true if obj and other refer to the same hash key.
       def eql?(o)
         self.class    == o.class &&
-        name.downcase == o.name.downcase
+        name.downcase == o.name.downcase &&
+        self.sanitized_sql == o.sanitized_sql
+      end
+
+      def sanitized_sql
+        @sanitized_sql ||= Utils::SqlSanitizer.new(sql).to_s
       end
 
       private

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -27,6 +27,18 @@ module ScoutApm
         end
       end
 
+      # For the layer lookup. Doesn't look @ SQL as unsanitized SQL will likely be more prevalant. This will treat different SQL calls to the same model as the same.
+      def hash
+        h = name.downcase.hash
+        h
+      end
+
+      # For the layer lookup. Doesn't look @ SQL as unsanitized SQL will likely be more prevalant. This will treat different SQL calls to the same model as the same.
+      def eql?(o)
+        self.class    == o.class &&
+        name.downcase == o.name.downcase
+      end
+
       private
 
       def model

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -30,7 +30,6 @@ module ScoutApm
       # For the layer lookup.
       def hash
         h = name.downcase.hash
-        h ^= sanitized_sql.hash unless sanitized_sql.nil? # can't think of a case where this would be nil, but just in case...
         h
       end
 
@@ -38,12 +37,7 @@ module ScoutApm
       # Reminder: #eql? is for Hash equality: returns true if obj and other refer to the same hash key.
       def eql?(o)
         self.class    == o.class &&
-        name.downcase == o.name.downcase &&
-        self.sanitized_sql == o.sanitized_sql
-      end
-
-      def sanitized_sql
-        @sanitized_sql ||= Utils::SqlSanitizer.new(sql).to_s
+        name.downcase == o.name.downcase
       end
 
       private

--- a/lib/scout_apm/utils/backtrace_parser.rb
+++ b/lib/scout_apm/utils/backtrace_parser.rb
@@ -18,7 +18,6 @@ module ScoutApm
         # Only the first element is used in Github code display.
         stack = []
         @call_stack.each_with_index do |c,i|
-          # TODO - don't gsub every time ... store it.
           if m = c.match(@@app_dir_regex)
             stack << m[2]
             break

--- a/lib/scout_apm/utils/backtrace_parser.rb
+++ b/lib/scout_apm/utils/backtrace_parser.rb
@@ -1,0 +1,32 @@
+require 'scout_apm/environment'
+
+# Removes actual values from SQL. Used to both obfuscate the SQL and group
+# similar queries in the UI.
+module ScoutApm
+  module Utils
+    class BacktraceParser
+
+      def initialize(call_stack)
+        @call_stack = call_stack
+        # We can't use a constant as it'd be too early to fetch environment info
+        @@app_dir_regex ||= /\A(#{ScoutApm::Environment.instance.root.to_s.gsub('/','\/')}\/)(app\/(.+))/.freeze
+      end
+
+      # Given a call stack Array, grabs the first call within the application root directory.
+      def call
+        # We used to return an array of up to 5 elements...this will return a single element-array for backwards compatibility.
+        # Only the first element is used in Github code display.
+        stack = []
+        @call_stack.each_with_index do |c,i|
+          # TODO - don't gsub every time ... store it.
+          if m = c.match(@@app_dir_regex)
+            stack << m[2]
+            break
+          end
+        end
+        stack
+      end
+
+    end
+  end
+end

--- a/lib/scout_apm/utils/sql_sanitizer.rb
+++ b/lib/scout_apm/utils/sql_sanitizer.rb
@@ -17,6 +17,7 @@ module ScoutApm
       def initialize(sql)
         @raw_sql = sql
         @database_engine = ScoutApm::Environment.instance.database_engine
+        @sanitized = false # only sanitize once.
       end
 
       def sql
@@ -24,6 +25,11 @@ module ScoutApm
       end
 
       def to_s
+        if @sanitized
+          sql
+        else
+          @sanitized = true
+        end
         case database_engine
         when :postgres then to_s_postgres
         when :mysql    then to_s_mysql

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,4 +1,4 @@
 module ScoutApm
-  VERSION = "1.4.5"
+  VERSION = "1.5.1.pre"
 end
 


### PR DESCRIPTION
This implements a performance-compliant version of n+1 backtrace colllection. 

See #36 for the original start.

We'll want to add this to jobs after running this for a bit.