### PR TITLE
Handle nil ignore_traces when ignoring trace patterns

### DIFF
--- a/lib/scout_apm/layer_converters/slow_request_converter.rb
+++ b/lib/scout_apm/layer_converters/slow_request_converter.rb
@@ -31,7 +31,7 @@ module ScoutApm
 
         uri = request.annotations[:uri] || ""
 
-        ScoutApm::Agent.instance.config.value("ignore_traces").each do |pattern|
+        (ScoutApm::Agent.instance.config.value("ignore_traces") || []).each do |pattern|
           if /#{pattern}/ =~ uri
             ScoutApm::Agent.instance.logger.debug("Skipped recording a trace for #{uri} due to `ignore_traces` pattern: #{pattern}")
             return nil


### PR DESCRIPTION
This change handles a bug where [the default `ignore_traces` setting (which is an empty array)](https://github.com/scoutapp/scout_apm_ruby/blob/master/lib/scout_apm/config.rb#L33) gets converted to `nil` and then `each` is called, raising an exception.

The `nil` conversion is due to the fact that there is [a length check in the `#value` method](https://github.com/scoutapp/scout_apm_ruby/blob/master/lib/scout_apm/config.rb#L58), that if zero returns `nil`.

I used the `(value || [])` approach here as I noticed that style being used for [the `disabled_instruments` option](https://github.com/scoutapp/scout_apm_ruby/blob/master/lib/scout_apm/agent.rb#L287). That said, it ultimately seems like the logic for reading values out of the config should handle arrays as first-class citizens. Setting an empty array as a default value isn't really worthwhile if the method to read the value out converts it to `nil`.

Let me know if you'd prefer to handle this some other way, but I figured I'd submit a PR since I debugged the issue locally when upgrading our gem version.