### PR TITLE
when fetching the app name for the post-deploy hook, use the deploy-to environment when possible (as represented by Capistrano stage)

### DIFF
--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -40,10 +40,10 @@ module ScoutApm
     # Load up a config instance, attempting to load a yaml file.  Allows a
     # definite location if requested, or will attempt to load the default
     # configuration file: APP_ROOT/config/scout_apm.yml
-    def self.with_file(file_path=nil)
+    def self.with_file(file_path=nil, config={})
       overlays = [
         ConfigEnvironment.new,
-        ConfigFile.new(file_path),
+        ConfigFile.new(file_path, config[:file]),
         ConfigDefaults.new,
       ]
       new(overlays)
@@ -104,7 +104,8 @@ module ScoutApm
     # is not found, inaccessbile, or unparsable, log a message to that effect,
     # and move on.
     class ConfigFile
-      def initialize(file_path=nil)
+      def initialize(file_path=nil, config={})
+        @config = config || {}
         @resolved_file_path = file_path || determine_file_path
         load_file(@resolved_file_path)
       end
@@ -162,9 +163,8 @@ module ScoutApm
       end
 
       def app_environment
-        ScoutApm::Environment.instance.env
+        @config[:environment] || ScoutApm::Environment.instance.env
       end
-
       def logger
         if ScoutApm::Agent.instance.logger
           return ScoutApm::Agent.instance.logger

--- a/lib/scout_apm/deploy_integrations/capistrano_3.rb
+++ b/lib/scout_apm/deploy_integrations/capistrano_3.rb
@@ -58,7 +58,13 @@ module ScoutApm
       end
 
       def reporter
-        @reporter ||= ScoutApm::Reporter.new(:deploy_hook, ScoutApm::Agent.instance.config, @logger)
+        config =  if env.blank?
+                    ScoutApm::Agent.instance.config
+                  else
+                    ScoutApm::Config.with_file(nil, {:file => { :environment => env }}) # instantiate our own config, with an overridden environment for the deploy-to app name instead of deploy-from app name)
+                  end
+
+        @reporter ||= ScoutApm::Reporter.new(:deploy_hook, config, @logger)
       end
 
       def deploy_data


### PR DESCRIPTION
Addresses https://github.com/scoutapp/scout_apm_ruby/issues/43

This isn't intended to fix deploy tracking for everyone everywhere, just makes it work for us again so we can see a real deploy record for APM.