### PR TITLE
Dev traces

### DIFF
--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -260,7 +260,7 @@ module ScoutApm
     # If we want to skip the app_server_check, then we must load it.
     def should_load_instruments?(options={})
       return true if options[:skip_app_server_check]
-      return true if config.value('instant')
+      return true if config.value('dev_trace')
       return false if !apm_enabled?
       environment.app_server_integration.found? || !background_job_missing?
     end

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -16,6 +16,7 @@ require 'scout_apm/environment'
 # name             - override the name reported to APM. This is the name that shows in the Web UI
 # uri_reporting    - 'path' or 'full_path' default is 'full_path', which reports URL params as well as the path.
 # report_format    - 'json' or 'marshal'. Marshal is legacy and will be removed.
+# dev_trace        - true or false. Enables always-on tracing in development environmen only
 #
 # Any of these config settings can be set with an environment variable prefixed
 # by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
@@ -73,7 +74,7 @@ module ScoutApm
         'disabled_instruments'   => [],
         'enable_background_jobs' => true,
         'ignore_traces' => [],
-        'instant' => false, # false for now so code can live in main branch
+        'dev_trace' => false, # false for now so code can live in main branch
       }.freeze
 
       def value(key)

--- a/lib/scout_apm/instant/middleware.rb
+++ b/lib/scout_apm/instant/middleware.rb
@@ -47,7 +47,7 @@ module ScoutApm
       def call(env)
         status, headers, response = @app.call(env)
 
-        if ScoutApm::Agent.instance.config.value('instant')
+        if ScoutApm::Agent.instance.config.value('dev_trace')
           if response.respond_to?(:body)
             req = ScoutApm::RequestManager.lookup
             slow_converter = LayerConverters::SlowRequestConverter.new(req)

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -39,8 +39,6 @@ module ScoutApm
     # this is set in the controller instumentation (ActionControllerRails3Rails4 according)
     attr_accessor :instant_key
 
-    BACKTRACE_THRESHOLD = 0.5 # the minimum threshold in seconds to record the backtrace for a metric.
-
     def initialize(store)
       @store = store #this is passed in so we can use a real store (normal operation) or fake store (instant mode only)
       @layers = []
@@ -118,7 +116,7 @@ module ScoutApm
       return false unless (web? || job?)
 
       # Capture any individually slow layer.
-      return true if layer.total_exclusive_time > BACKTRACE_THRESHOLD
+      return true if layer.total_exclusive_time > backtrace_threshold
 
       # Capture any layer that we've seen many times. Captures n+1 problems
       return true if @call_set[layer.name].capture_backtrace?
@@ -308,5 +306,11 @@ module ScoutApm
     def ignoring_children?
       @ignoring_children
     end
+
+    # Grab backtraces more aggressively when running in dev trace mode
+    def backtrace_threshold
+      instant? ? 0.1 : 0.5 # the minimum threshold in seconds to record the backtrace for a metric.
+    end
+
   end
 end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -39,6 +39,9 @@ module ScoutApm
     # this is set in the controller instumentation (ActionControllerRails3Rails4 according)
     attr_accessor :instant_key
 
+    # Whereas the instant_key gets set per-request in reponse to a URL param, dev_trace is set in the config file
+    attr_accessor :dev_trace
+
     def initialize(store)
       @store = store #this is passed in so we can use a real store (normal operation) or fake store (instant mode only)
       @layers = []
@@ -50,6 +53,7 @@ module ScoutApm
       @error = false
       @instant_key = nil
       @mem_start = mem_usage
+      @dev_trace =  ScoutApm::Agent.instance.config.value('dev_trace') && Rails.env.development?
     end
 
     def start_layer(layer)
@@ -309,7 +313,7 @@ module ScoutApm
 
     # Grab backtraces more aggressively when running in dev trace mode
     def backtrace_threshold
-      instant? ? 0.1 : 0.5 # the minimum threshold in seconds to record the backtrace for a metric.
+      dev_trace ? 0.05 : 0.5 # the minimum threshold in seconds to record the backtrace for a metric.
     end
 
   end


### PR DESCRIPTION
* change the config setting from instant to `dev_trace`
* lower the threshold for collecting backtraces when running dev_trace