### PR TITLE
Use 1.8 compatible hash syntax in Instant::Middleware

### DIFF
--- a/lib/scout_apm/instant/middleware.rb
+++ b/lib/scout_apm/instant/middleware.rb
@@ -61,7 +61,7 @@ module ScoutApm
                   :platform      => "ruby",
               }
               hash = ScoutApm::Serializers::PayloadSerializerToJson.rearrange_slow_transaction(trace)
-              hash.merge!(metadata:metadata)
+              hash.merge!(:metadata => metadata)
               payload = ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(hash)
 
               if env['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest' || content_type.include?("application/json")


### PR DESCRIPTION
Ran into this when testing out the latest gem version locally on Ruby 1.8.7.