### PR TITLE
Better security-by-default for Transaction Trace URIs

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# 2.1.2
+
+* Applies `Rails.application.config.filter_parameters` settings to reported transaction trace uris
+
 # 2.1.1
 
 * Fix an issue with AR instrumentation and complex queries

--- a/lib/scout_apm/instruments/action_controller_rails_2.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_2.rb
@@ -48,8 +48,7 @@ module ScoutApm
       # specific controller actions.
       def perform_action_with_scout_instruments(*args, &block)
         req = ScoutApm::RequestManager.lookup
-        path = ScoutApm::Agent.instance.config.value("uri_reporting") == 'path' ? request.path : request.fullpath
-        req.annotate_request(:uri => path)
+        req.annotate_request(:uri => request.path) # for security by-default, we don't use request.fullpath which could reveal filtered params.
         req.context.add_user(:ip => request.remote_ip)
         req.set_headers(request.headers)
         req.start_layer( ScoutApm::Layer.new("Controller", "#{controller_path}/#{action_name}") )

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -59,8 +59,7 @@ module ScoutApm
     module ActionControllerRails3Rails4Instruments
       def process_action(*args)
         req = ScoutApm::RequestManager.lookup
-        path = ScoutApm::Agent.instance.config.value("uri_reporting") == 'path' ? request.path : request.fullpath
-        req.annotate_request(:uri => path)
+        req.annotate_request(:uri => scout_transaction_uri(request))
 
         # IP Spoofing Protection can throw an exception, just move on w/o remote ip
         req.context.add_user(:ip => request.remote_ip) rescue nil
@@ -84,8 +83,19 @@ module ScoutApm
         ensure
           req.stop_layer
         end
+      end # process_action
+
+      # Given an +ActionDispatch::Request+, formats the uri based on config settings.
+      def scout_transaction_uri(request)
+        case ScoutApm::Agent.instance.config.value("uri_reporting")
+        when 'path'
+          request.path # strips off the query string for more security
+        else # default handles filtered params
+          request.filtered_path
+        end
       end
-    end
+
+    end # ActionControllerRails3Rails4Instruments
   end
 end
 

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,4 +1,4 @@
 module ScoutApm
-  VERSION = "2.1.1"
+  VERSION = "2.1.2.pre"
 end
 


### PR DESCRIPTION
Applying `filtered_parameters` settings to Rails 3+ trace uris. For Rails 2, just reporting the path.

These are better security-by-default settings for transaction trace uris. Example formatting of URIs for Rails 3+ reported to Scout:

`/users?password=secret&limit=10 => /users?password=[FILTERED]&limit=10`