### PR TITLE
Less noisy output on errors with Context.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # master
 
+* Less noisy output on errors with Context
+  * Not logging errors w/nil keys or values
+  * Bumping log level down from WARN => INFO on errors
+
 # 2.1.2
 
 * Applies `Rails.application.config.filter_parameters` settings to reported transaction trace uris

--- a/lib/scout_apm/context.rb
+++ b/lib/scout_apm/context.rb
@@ -75,8 +75,10 @@ module ScoutApm
     def value_valid?(key_value)
       # ensure one of our accepted types.
       value = key_value.values.last
-      if !valid_type?([String, Symbol, Numeric, Time, Date, TrueClass, FalseClass],value)
-        ScoutApm::Agent.instance.logger.warn "The value for [#{key_value.keys.first}] is not a valid type [#{value.class}]."
+      if value.nil?
+        false # don't log this ... easy to happen
+      elsif !valid_type?([String, Symbol, Numeric, Time, Date, TrueClass, FalseClass],value)
+        ScoutApm::Agent.instance.logger.info "The value for [#{key_value.keys.first}] is not a valid type [#{value.class}]."
         false
       else
         true
@@ -86,14 +88,16 @@ module ScoutApm
     # for consistently with #value_valid?, takes a hash eventhough the value isn't yet used.
     def key_valid?(key_value)
       key = key_value.keys.first
+      if key.nil?
+        false # don't log this ... easy to happen
       # ensure a string or a symbol
-      if !valid_type?([String, Symbol],key)
-        ScoutApm::Agent.instance.logger.warn "The key [#{key}] is not a valid type [#{key.class}]."
+      elsif !valid_type?([String, Symbol],key)
+        ScoutApm::Agent.instance.logger.info "The key [#{key}] is not a valid type [#{key.class}]."
         return false
       end
       # only alphanumeric, dash, and underscore allowed.
       if key.to_s.match(/[^\w-]/)
-        ScoutApm::Agent.instance.logger.warn "They key name [#{key}] is not valid."
+        ScoutApm::Agent.instance.logger.info "They key name [#{key}] is not valid."
         return false
       end
       true

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+require 'scout_apm/context'
+
+class ContextText < Minitest::Test
+  def test_ignore_nil_value
+    context = ScoutApm::Context.new
+    assert hash = context.add(:nil_key => nil, :org => 'org')
+    assert_equal ({:org => 'org'}), hash
+  end
+
+  def test_ignore_nil_key
+    context = ScoutApm::Context.new
+    assert hash = context.add(nil => nil, :org => 'org')
+    assert_equal ({:org => 'org'}), hash
+  end
+
+  def test_ignore_unsupported_value_type
+    context = ScoutApm::Context.new
+    assert hash = context.add(:array => [1,2,3,4], :org => 'org')
+    assert_equal ({:org => 'org'}), hash
+  end
+
+  def test_ignore_unsupported_key_type
+    context = ScoutApm::Context.new
+    assert hash = context.add([1,2,3,4] => 'hey', :org => 'org')
+    assert_equal ({:org => 'org'}), hash
+  end
+end
+


### PR DESCRIPTION
This brings down our logging output when handling issues with invalid Context keys and values:

* Not logging errors w/nil keys or values
* Bumping log level down from `WARN` => `INFO`

A unit test has also been added for Context.