### PR TITLE
This refines what it means to be "in-app" when it comes to backtraces

### DIFF
--- a/lib/scout_apm/utils/backtrace_parser.rb
+++ b/lib/scout_apm/utils/backtrace_parser.rb
@@ -14,7 +14,10 @@ module ScoutApm
       def initialize(call_stack, root=ScoutApm::Environment.instance.root)
         @call_stack = call_stack
         # We can't use a constant as it'd be too early to fetch environment info
-        @@app_dir_regex = %r|#{root}/(.*)|
+        #
+        # This regex looks for files under the app root, inside lib/, app/, and
+        # config/ dirs, and captures the path under root.
+        @@app_dir_regex = %r|#{root}/((?:lib/|app/|config/).*)|
       end
 
       def call

--- a/lib/scout_apm/utils/backtrace_parser.rb
+++ b/lib/scout_apm/utils/backtrace_parser.rb
@@ -17,7 +17,7 @@ module ScoutApm
         #
         # This regex looks for files under the app root, inside lib/, app/, and
         # config/ dirs, and captures the path under root.
-        @@app_dir_regex = %r|#{root}/((?:lib/|app/|config/).*)|
+        @@app_dir_regex = %r[#{root}/((?:lib/|app/|config/).*)]
       end
 
       def call
@@ -30,7 +30,6 @@ module ScoutApm
         end
         stack
       end
-
     end
   end
 end

--- a/test/unit/utils/backtrace_parser_test.rb
+++ b/test/unit/utils/backtrace_parser_test.rb
@@ -49,4 +49,18 @@ class BacktraceParserTest < Minitest::Test
     result = ScoutApm::Utils::BacktraceParser.new(raw_backtrace, "/Users/scout/different-secrets").call
     assert_equal 0, result.length
   end
+
+  def test_excludes_vendor_paths
+    raw_backtrace = [
+      "#{root}/vendor/ruby/thing.rb",
+      "#{root}/app/controllers/users_controller.rb",
+      "#{root}/vendor/ruby/thing.rb",
+      "#{root}/config/initializers/inject_something.rb",
+    ]
+    result = ScoutApm::Utils::BacktraceParser.new(raw_backtrace, root).call
+
+    assert_equal 2, result.length
+    assert_equal false, (result[0] =~ %r|app/controllers/users_controller.rb|).nil?
+    assert_equal false, (result[1] =~ %r|config/initializers/inject_something.rb|).nil?
+  end
 end


### PR DESCRIPTION
If you're in the Rails root, and inside lib/ app/ or config/, then you
are.  This prevents directories like vendor/ from showing up in the UI
as code the user owns directly.