### PR TITLE
Only call shutdown once per process.

### DIFF
--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -203,18 +203,20 @@ module ScoutApm
     # It does not attempt to actually report metrics.
     def shutdown
       logger.info "Shutting down ScoutApm"
+
       return if !started?
+
+      return if @shutdown
+      @shutdown = true
 
       if @background_worker
         logger.info("Stopping background worker")
         @background_worker.stop
         store.write_to_layaway(layaway, :force)
-      end
-
-      logger.debug "Joining background worker thread"
-      if @background_worker_thread
-        @background_worker_thread.wakeup
-        @background_worker_thread.join
+        if @background_worker_thread.alive?
+          @background_worker_thread.wakeup
+          @background_worker_thread.join
+        end
       end
     end
 


### PR DESCRIPTION
Also adds safety around the call that actually broke if you called
shutdown twice.

The case this happened is in Passenger integration, where we have a hook
for the `stopping_worker_process` event, which called shutdown.  Then
the process actually stopped, which fired our at_exit handler, causing
shutdown to be called a second time.  That second time attempted to work
with the background thread that had been finished in the first call,
causing an error message to be emitted.