### PR TITLE
Refactor SlowRequestConverter and SlowJobConverter to merge shared logic

### DIFF
--- a/lib/scout_apm/layer_converters/converter_base.rb
+++ b/lib/scout_apm/layer_converters/converter_base.rb
@@ -1,6 +1,7 @@
 module ScoutApm
   module LayerConverters
     class ConverterBase
+
       attr_reader :walker
       attr_reader :request
       attr_reader :root_layer
@@ -8,7 +9,10 @@ module ScoutApm
       def initialize(request)
         @request = request
         @root_layer = request.root_layer
+        @backtraces = []
         @walker = DepthFirstWalker.new(root_layer)
+
+        @limited = false
       end
 
       # Scope is determined by the first Controller we hit.  Most of the time
@@ -26,6 +30,195 @@ module ScoutApm
         walker.walk do |layer|
           return layer if layer.type == layer_type
         end
+      end
+
+      ################################################################################
+      # Subscoping
+      ################################################################################
+      #
+      # Keep a list of subscopes, but only ever use the front one.  The rest
+      # get pushed/popped in cases when we have many levels of subscopable
+      # layers.  This lets us push/pop without otherwise keeping track very closely.
+      def setup_subscopable_callbacks
+        @subscope_layers = []
+
+        walker.before do |layer|
+          if layer.subscopable?
+            @subscope_layers.push(layer)
+          end
+        end
+
+        walker.after do |layer|
+          if layer.subscopable?
+            @subscope_layers.pop
+          end
+        end
+      end
+
+      def subscoped?(layer)
+        @subscope_layers.first && layer != @subscope_layers.first # Don't scope under ourself.
+      end
+
+      def subscope_name
+        @subscope_layers.first.legacy_metric_name
+      end
+
+
+      ################################################################################
+      # Backtrace Handling
+      ################################################################################
+      #
+      # Because we get several layers for the same thing if you call an
+      # instrumented thing repeatedly, and only some of them may have
+      # backtraces captured, we store the backtraces off into another spot
+      # during processing, then at the end, we loop over those saved
+      # backtraces, putting them back into the metrics hash.
+      #
+      # This comes up most often when capturing n+1 backtraces. Because the
+      # query may be fast enough to evade our time-limit based backtrace
+      # capture, only the Nth item (see TrackedRequest for more detail) has a
+      # backtrack captured.  This sequence makes sure that we report up that
+      # backtrace in the aggregated set of metrics around that call.
+
+      # Call this as you are processing each layer. It will store off backtraces
+      def store_backtrace(layer, meta)
+        return unless layer.backtrace
+
+        bt = ScoutApm::Utils::BacktraceParser.new(layer.backtrace).call
+        if bt.any?
+          meta.backtrace = bt
+          @backtraces << meta
+        else
+          ScoutApm::Agent.instance.logger.debug { "Unable to capture an app-specific backtrace for #{meta.inspect}\n#{layer.backtrace}" }
+        end
+      end
+
+      # Call this after you finish walking the layers, and want to take the
+      # set-aside backtraces and place them into the metas they match
+      def attach_backtraces(metric_hash)
+        @backtraces.each do |meta_with_backtrace|
+          metric_hash.keys.find { |k| k == meta_with_backtrace }.backtrace = meta_with_backtrace.backtrace
+        end
+        metric_hash
+      end
+
+
+      ################################################################################
+      # Limit Handling
+      ################################################################################
+
+      # To prevent huge traces from being generated, we should stop collecting
+      # detailed metrics as we go beyond some reasonably large count.
+      #
+      # We should still add up the /all aggregates.
+
+      MAX_METRICS = 500
+
+      def over_metric_limit?(metric_hash)
+        if metric_hash.size > MAX_METRICS
+          @limited = true
+        else
+          false
+        end
+      end
+
+      def limited?
+        !! @limited
+      end
+
+      ################################################################################
+      # Meta Scope
+      ################################################################################
+
+      # When we make MetricMeta records, we need to determine a few things from layer.
+      def make_meta_options(layer)
+        scope_hash = make_meta_options_scope(layer)
+        desc_hash = make_meta_options_desc_hash(layer)
+
+        scope_hash.merge(desc_hash)
+      end
+
+      def make_meta_options_scope(layer)
+        # This layer is scoped under another thing. Typically that means this is a layer under a view.
+        # Like: Controller -> View/users/show -> ActiveRecord/user/find
+        #   in that example, the scope is the View/users/show
+        if subscoped?(layer)
+          {:scope => subscope_name}
+
+        # We don't scope the controller under itself
+        elsif layer == scope_layer
+          {}
+
+        # This layer is a top level metric ("ActiveRecord", or "HTTP" or
+        # whatever, directly under the controller), so scope to the
+        # Controller
+        else
+          {:scope => scope_layer.legacy_metric_name}
+        end
+      end
+
+      def make_meta_options_desc_hash(layer)
+        if layer.desc
+          {:desc => layer.desc.to_s}
+        else
+          {}
+        end
+      end
+
+
+      ################################################################################
+      # Storing metrics into the hashes
+      ################################################################################
+
+      # This is the detailed metric - type, name, backtrace, annotations, etc.
+      def store_specific_metric(layer, metric_hash, allocation_metric_hash)
+        return false if over_metric_limit?(metric_hash)
+
+        meta_options = make_meta_options(layer)
+
+        meta = MetricMeta.new(layer.legacy_metric_name, meta_options)
+        meta.extra.merge!(layer.annotations)
+
+        store_backtrace(layer, meta)
+
+        metric_hash[meta] ||= MetricStats.new(meta_options.has_key?(:scope))
+        allocation_metric_hash[meta] ||= MetricStats.new(meta_options.has_key?(:scope))
+
+        # timing
+        stat = metric_hash[meta]
+        stat.update!(layer.total_call_time, layer.total_exclusive_time)
+
+        # allocations
+        stat = allocation_metric_hash[meta]
+        stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
+      end
+
+      # Merged Metric - no specifics, just sum up by type (ActiveRecord, View, HTTP, etc)
+      def store_aggregate_metric(layer, metric_hash, allocation_metric_hash)
+          meta = MetricMeta.new("#{layer.type}/all")
+
+          metric_hash[meta] ||= MetricStats.new(false)
+          allocation_metric_hash[meta] ||= MetricStats.new(false)
+
+          # timing
+          stat = metric_hash[meta]
+          stat.update!(layer.total_call_time, layer.total_exclusive_time)
+
+          # allocations
+          stat = allocation_metric_hash[meta]
+          stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
+      end
+
+      ################################################################################
+      # Misc Helpers
+      ################################################################################
+
+      # Sometimes we start capturing a layer without knowing if we really
+      # want to make an entry for it.  See ActiveRecord instrumentation for
+      # an example. We start capturing before we know if a query is cached
+      # or not, and want to skip any cached queries.
+      def skip_layer?(layer)
+        return true if layer.annotations[:ignorable]
       end
     end
   end

--- a/lib/scout_apm/layer_converters/slow_job_converter.rb
+++ b/lib/scout_apm/layer_converters/slow_job_converter.rb
@@ -2,7 +2,6 @@ module ScoutApm
   module LayerConverters
     class SlowJobConverter < ConverterBase
       def initialize(*)
-        @backtraces = []
         super
 
         # After call to super, so @request is populated
@@ -11,6 +10,8 @@ module ScoutApm
                   else
                     -1
                   end
+
+        setup_subscopable_callbacks
       end
 
       def name
@@ -32,6 +33,7 @@ module ScoutApm
         mem_delta = ScoutApm::Instruments::Process::ProcessMemory.rss_to_mb(request.capture_mem_delta!)
 
         timing_metrics, allocation_metrics = create_metrics
+
         unless ScoutApm::Instruments::Allocations::ENABLED
           allocation_metrics = {}
         end
@@ -47,7 +49,9 @@ module ScoutApm
           allocation_metrics,
           mem_delta,
           job_layer.total_allocations,
-          score)
+          score,
+          limited?
+        )
       end
 
       def queue_layer
@@ -58,92 +62,29 @@ module ScoutApm
         @job_layer ||= find_first_layer_of_type("Job")
       end
 
+      def skip_layer?(layer)
+        super(layer) || layer == queue_layer
+      end
+
       def create_metrics
         metric_hash = Hash.new
         allocation_metric_hash = Hash.new
 
-        # Keep a list of subscopes, but only ever use the front one.  The rest
-        # get pushed/popped in cases when we have many levels of subscopable
-        # layers.  This lets us push/pop without otherwise keeping track very closely.
-        subscope_layers = []
-
-        walker.before do |layer|
-          if layer.subscopable?
-            subscope_layers.push(layer)
-          end
-        end
-
-        walker.after do |layer|
-          if layer.subscopable?
-            subscope_layers.pop
-          end
-        end
-
         walker.walk do |layer|
-          # Sometimes we start capturing a layer without knowing if we really
-          # want to make an entry for it.  See ActiveRecord instrumentation for
-          # an example. We start capturing before we know if a query is cached
-          # or not, and want to skip any cached queries.
-          next if layer.annotations[:ignorable]
+          next if skip_layer?(layer)
 
           # The queue_layer is useful to capture for other reasons, but doesn't
           # create a MetricMeta/Stat of its own
           next if layer == queue_layer
 
-          meta_options = if subscope_layers.first && layer != subscope_layers.first # Don't scope under ourself.
-                           subscope_name = subscope_layers.first.legacy_metric_name
-                           {:scope => subscope_name}
-                         elsif layer == job_layer # We don't scope the controller under itself
-                           {}
-                         else
-                           {:scope => job_layer.legacy_metric_name}
-                         end
-
-          # Specific Metric
-          meta_options.merge!(:desc => layer.desc.to_s) if layer.desc
-          meta = MetricMeta.new(layer.legacy_metric_name, meta_options)
-          meta.extra.merge!(layer.annotations)
-
-          if layer.backtrace
-            bt = ScoutApm::Utils::BacktraceParser.new(layer.backtrace).call
-            if bt.any? # we could walk thru the call stack and not find in-app code
-              meta.backtrace = bt
-              # Why not just call meta.backtrace and call it done? The walker could access a later later that generates the same MetricMeta but doesn't have a backtrace. This could be
-              # lost in the metric_hash if it is replaced by the new key.
-              @backtraces << meta
-            else
-              ScoutApm::Agent.instance.logger.debug { "Unable to capture an app-specific backtrace for #{meta.inspect}\n#{layer.backtrace}" }
-            end
-          end
-
-          metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )
-          allocation_metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )
-          stat = metric_hash[meta]
-          stat.update!(layer.total_call_time, layer.total_exclusive_time)
-          stat = allocation_metric_hash[meta]
-          stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
-
-          # Merged Metric (no specifics, just sum up by type)
-          meta = MetricMeta.new("#{layer.type}/all")
-          metric_hash[meta] ||= MetricStats.new(false)
-          allocation_metric_hash[meta] ||= MetricStats.new(false)
-          stat = metric_hash[meta]
-          stat.update!(layer.total_call_time, layer.total_exclusive_time)
-          stat = allocation_metric_hash[meta]
-          stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
+          store_specific_metric(layer, metric_hash, allocation_metric_hash)
+          store_aggregate_metric(layer, metric_hash, allocation_metric_hash)
         end
 
         metric_hash = attach_backtraces(metric_hash)
         allocation_metric_hash = attach_backtraces(allocation_metric_hash)
 
-        [metric_hash,allocation_metric_hash]
-      end
-
-      def attach_backtraces(metric_hash)
-        @backtraces.each do |meta_with_backtrace|
-          metric_hash.keys.find { |k| k == meta_with_backtrace }.backtrace = meta_with_backtrace.backtrace
-        end
-        metric_hash
+        [metric_hash, allocation_metric_hash]
       end
     end
   end

--- a/lib/scout_apm/layer_converters/slow_request_converter.rb
+++ b/lib/scout_apm/layer_converters/slow_request_converter.rb
@@ -2,7 +2,6 @@ module ScoutApm
   module LayerConverters
     class SlowRequestConverter < ConverterBase
       def initialize(*)
-        @backtraces = [] # An Array of MetricMetas that have a backtrace
         super
 
         # After call to super, so @request is populated
@@ -11,6 +10,8 @@ module ScoutApm
                   else
                     -1
                   end
+
+        setup_subscopable_callbacks
       end
 
       def name
@@ -24,8 +25,8 @@ module ScoutApm
       # Unconditionally attempts to convert this into a SlowTransaction object.
       # Can return nil if the request didn't have any scope_layer.
       def call
-        scope = scope_layer
-        return nil unless scope
+        return nil unless request.web?
+        return nil unless scope_layer
 
         ScoutApm::Agent.instance.slow_request_policy.stored!(request)
 
@@ -35,12 +36,13 @@ module ScoutApm
         uri = request.annotations[:uri] || ""
 
         timing_metrics, allocation_metrics = create_metrics
+
         unless ScoutApm::Instruments::Allocations::ENABLED
           allocation_metrics = {}
         end
 
         SlowTransaction.new(uri,
-                            scope.legacy_metric_name,
+                            scope_layer.legacy_metric_name,
                             root_layer.total_call_time,
                             timing_metrics,
                             allocation_metrics,
@@ -49,103 +51,29 @@ module ScoutApm
                             [], # stackprof, now unused.
                             mem_delta,
                             root_layer.total_allocations,
-                            @points)
-      end
-
-      # Iterates over the TrackedRequest's MetricMetas that have backtraces and attaches each to correct MetricMeta in the Metric Hash.
-      def attach_backtraces(metric_hash)
-        @backtraces.each do |meta_with_backtrace|
-          metric_hash.keys.find { |k| k == meta_with_backtrace }.backtrace = meta_with_backtrace.backtrace
-        end
-        metric_hash
+                            @points,
+                            limited?)
       end
 
       # Full metrics from this request. These get stored permanently in a SlowTransaction.
       # Some merging of metrics will happen here, so if a request calls the same
       # ActiveRecord or View repeatedly, it'll get merged.
-      # 
+      #
       # This returns a 2-element of Metric Hashes (the first element is timing metrics, the second element is allocation metrics)
       def create_metrics
         metric_hash = Hash.new
         allocation_metric_hash = Hash.new
 
-        # Keep a list of subscopes, but only ever use the front one.  The rest
-        # get pushed/popped in cases when we have many levels of subscopable
-        # layers.  This lets us push/pop without otherwise keeping track very closely.
-        subscope_layers = []
-
-        walker.before do |layer|
-          if layer.subscopable?
-            subscope_layers.push(layer)
-          end
-        end
-
-        walker.after do |layer|
-          if layer.subscopable?
-            subscope_layers.pop
-          end
-        end
-
         walker.walk do |layer|
-          # Sometimes we start capturing a layer without knowing if we really
-          # want to make an entry for it.  See ActiveRecord instrumentation for
-          # an example. We start capturing before we know if a query is cached
-          # or not, and want to skip any cached queries.
-          if layer.annotations[:ignorable]
-            next
-          end
-
-          meta_options = if subscope_layers.first && layer != subscope_layers.first # Don't scope under ourself.
-                           subscope_name = subscope_layers.first.legacy_metric_name
-                           {:scope => subscope_name}
-                         elsif layer == scope_layer # We don't scope the controller under itself
-                           {}
-                         else
-                           {:scope => scope_layer.legacy_metric_name}
-                         end
-
-          # Specific Metric
-          meta_options.merge!(:desc => layer.desc.to_s) if layer.desc
-          meta = MetricMeta.new(layer.legacy_metric_name, meta_options)
-          meta.extra.merge!(layer.annotations)
-          if layer.backtrace
-            bt = ScoutApm::Utils::BacktraceParser.new(layer.backtrace).call
-            if bt.any? # we could walk thru the call stack and not find in-app code
-              meta.backtrace = bt
-              # Why not just call meta.backtrace and call it done? The walker
-              # could access a later later that generates the same MetricMeta
-              # but doesn't have a backtrace. This could be lost in the
-              # metric_hash if it is replaced by the new key.
-              @backtraces << meta
-            else
-              ScoutApm::Agent.instance.logger.debug { "Unable to capture an app-specific backtrace for #{meta.inspect}\n#{layer.backtrace}" }
-            end
-          end
-          metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )
-          allocation_metric_hash[meta] ||= MetricStats.new( meta_options.has_key?(:scope) )
-          # timing
-          stat = metric_hash[meta]
-          stat.update!(layer.total_call_time, layer.total_exclusive_time)
-          # allocations
-          stat = allocation_metric_hash[meta]
-          stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
-
-          # Merged Metric (no specifics, just sum up by type)
-          meta = MetricMeta.new("#{layer.type}/all")
-          metric_hash[meta] ||= MetricStats.new(false)
-          allocation_metric_hash[meta] ||= MetricStats.new(false)
-          # timing
-          stat = metric_hash[meta]
-          stat.update!(layer.total_call_time, layer.total_exclusive_time)
-          # allocations
-          stat = allocation_metric_hash[meta]
-          stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
+          next if skip_layer?(layer)
+          store_specific_metric(layer, metric_hash, allocation_metric_hash)
+          store_aggregate_metric(layer, metric_hash, allocation_metric_hash)
         end
 
         metric_hash = attach_backtraces(metric_hash)
         allocation_metric_hash = attach_backtraces(allocation_metric_hash)
 
-        [metric_hash,allocation_metric_hash]
+        [metric_hash, allocation_metric_hash]
       end
     end
   end

--- a/lib/scout_apm/serializers/slow_jobs_serializer_to_json.rb
+++ b/lib/scout_apm/serializers/slow_jobs_serializer_to_json.rb
@@ -25,6 +25,7 @@ module ScoutApm
             "metrics" => MetricsToJsonSerializer.new(job.metrics).as_json, # New style of metrics
             "allocation_metrics" => MetricsToJsonSerializer.new(job.allocation_metrics).as_json, # New style of metrics
             "context" => job.context.to_hash,
+            "truncated_metrics" => job.truncated_metrics,
 
             "score" => job.score,
           }
@@ -33,4 +34,3 @@ module ScoutApm
     end
   end
 end
-

--- a/lib/scout_apm/slow_job_record.rb
+++ b/lib/scout_apm/slow_job_record.rb
@@ -21,8 +21,9 @@ module ScoutApm
     attr_reader :seconds_since_startup
     attr_reader :score
     attr_reader :git_sha
+    attr_reader :truncated_metrics
 
-    def initialize(queue_name, job_name, time, total_time, exclusive_time, context, metrics, allocation_metrics, mem_delta, allocations, score)
+    def initialize(queue_name, job_name, time, total_time, exclusive_time, context, metrics, allocation_metrics, mem_delta, allocations, score, truncated_metrics)
       @queue_name = queue_name
       @job_name = job_name
       @time = time
@@ -37,6 +38,8 @@ module ScoutApm
       @hostname = ScoutApm::Environment.instance.hostname
       @git_sha = ScoutApm::Environment.instance.git_revision.sha
       @score = score
+      @truncated_metrics = truncated_metrics
+
       ScoutApm::Agent.instance.logger.debug { "Slow Job [#{metric_name}] - Call Time: #{total_call_time} Mem Delta: #{mem_delta}"}
     end
 

--- a/lib/scout_apm/slow_transaction.rb
+++ b/lib/scout_apm/slow_transaction.rb
@@ -16,8 +16,9 @@ module ScoutApm
     attr_accessor :hostname # hack - we need to reset these server side.
     attr_accessor :seconds_since_startup # hack - we need to reset these server side.
     attr_accessor :git_sha # hack - we need to reset these server side.
+    attr_reader :truncated_metrics
 
-    def initialize(uri, metric_name, total_call_time, metrics, allocation_metrics, context, time, raw_stackprof, mem_delta, allocations, score)
+    def initialize(uri, metric_name, total_call_time, metrics, allocation_metrics, context, time, raw_stackprof, mem_delta, allocations, score, truncated_metrics)
       @uri = uri
       @metric_name = metric_name
       @total_call_time = total_call_time
@@ -32,6 +33,8 @@ module ScoutApm
       @hostname = ScoutApm::Environment.instance.hostname
       @score = score
       @git_sha = ScoutApm::Environment.instance.git_revision.sha
+      @truncated_metrics = truncated_metrics
+
       ScoutApm::Agent.instance.logger.debug { "Slow Request [#{uri}] - Call Time: #{total_call_time} Mem Delta: #{mem_delta} Score: #{score}"}
     end
 

--- a/lib/scout_apm/slow_transaction.rb
+++ b/lib/scout_apm/slow_transaction.rb
@@ -16,7 +16,8 @@ module ScoutApm
     attr_accessor :hostname # hack - we need to reset these server side.
     attr_accessor :seconds_since_startup # hack - we need to reset these server side.
     attr_accessor :git_sha # hack - we need to reset these server side.
-    attr_reader :truncated_metrics
+
+    attr_reader :truncated_metrics # True/False that says if we had to truncate the metrics of this trace
 
     def initialize(uri, metric_name, total_call_time, metrics, allocation_metrics, context, time, raw_stackprof, mem_delta, allocations, score, truncated_metrics)
       @uri = uri
@@ -49,7 +50,19 @@ module ScoutApm
     end
 
     def as_json
-      json_attributes = [:key, :time, :total_call_time, :uri, [:context, :context_hash], :score, :prof, :mem_delta, :allocations, :seconds_since_startup, :hostname, :git_sha]
+      json_attributes = [:key,
+                         :time,
+                         :total_call_time,
+                         :uri,
+                         [:context, :context_hash],
+                         :score,
+                         :prof,
+                         :mem_delta,
+                         :allocations,
+                         :seconds_since_startup,
+                         :hostname,
+                         :git_sha,
+                         :truncated_metrics]
       ScoutApm::AttributeArranger.call(self, json_attributes)
     end
 


### PR DESCRIPTION
This also implements a cap on the number of metrics stored in any given
trace (500 currently).  This is a number beyond what the majority of
requests hit, but should help prevent performance hits and giant payloads.