### PR TITLE
Handle Addressable::URI in addition to URI

### DIFF
--- a/lib/scout_apm/instruments/net_http.rb
+++ b/lib/scout_apm/instruments/net_http.rb
@@ -22,10 +22,15 @@ module ScoutApm
             include ScoutApm::Tracer
 
             def request_with_scout_instruments(*args,&block)
-              url = (@address + args.first.path.split('?').first)[0..99]
-              self.class.instrument("HTTP", "request", :desc => url) do
+              self.class.instrument("HTTP", "request", :desc => request_scout_description(args.first)) do
                 request_without_scout_instruments(*args, &block)
               end
+            end
+
+            def request_scout_description(req)
+              path = req.path
+              path = path.path if path.respond_to?(:path)
+              (@address + path.split('?').first)[0..99]
             end
 
             alias request_without_scout_instruments request

--- a/scout_apm.gemspec
+++ b/scout_apm.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "m"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "rake-compiler"
+  s.add_development_dependency "addressable"
 end

--- a/test/unit/instruments/net_http_test.rb
+++ b/test/unit/instruments/net_http_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+require 'scout_apm/instruments/net_http'
+
+require 'addressable'
+
+class NetHttpTest < Minitest::Test
+  def setup
+    ScoutApm::Instruments::NetHttp.new.install
+  end
+
+  def test_request_scout_description_for_uri
+    req = Net::HTTP::Get.new(URI('http://example.org/here'))
+    assert_equal '/here', Net::HTTP.new('').request_scout_description(req)
+  end
+
+  def test_request_scout_description_for_addressable
+    req = Net::HTTP::Get.new(Addressable::URI.parse('http://example.org/here'))
+    assert_equal '/here', Net::HTTP.new('').request_scout_description(req)
+  end
+end


### PR DESCRIPTION
I've application code using Addressable::URI thus

    addressable_uri = Addressable::URI.parse(uri)
    Net::HTTP.get(addressable_uri)

This break with an exception being thrown by
`lib/scout_apm/instruments/net_http.rb`. One possilbe solution would be

    addressable_uri = URI(uri)
    Net::HTTP.get(addressable_uri)

But I'm on ruby 2.1.9 and have to handle subdomains with underscores,
see https://bugs.ruby-lang.org/issues/9974. So until I can update ruby >
2.1 my application code breaks with scout_apm.

This commit make scout_apm request profiling usable with both
Addressable::URI and URI.