### PR TITLE
Don't create unnecessary variables in Layer#initialize

### DIFF
--- a/lib/scout_apm/layer_converters/converter_base.rb
+++ b/lib/scout_apm/layer_converters/converter_base.rb
@@ -177,7 +177,7 @@ module ScoutApm
         meta_options = make_meta_options(layer)
 
         meta = MetricMeta.new(layer.legacy_metric_name, meta_options)
-        meta.extra.merge!(layer.annotations)
+        meta.extra.merge!(layer.annotations) if layer.annotations
 
         store_backtrace(layer, meta)
 
@@ -218,7 +218,8 @@ module ScoutApm
       # an example. We start capturing before we know if a query is cached
       # or not, and want to skip any cached queries.
       def skip_layer?(layer)
-        return true if layer.annotations[:ignorable]
+        return false if layer.annotations.nil?
+        return true  if layer.annotations[:ignorable]
       end
     end
   end

--- a/lib/scout_apm/layer_converters/job_converter.rb
+++ b/lib/scout_apm/layer_converters/job_converter.rb
@@ -57,7 +57,7 @@ module ScoutApm
         walker.walk do |layer|
           next if layer == job_layer
           next if layer == queue_layer
-          next if layer.annotations[:ignorable]
+          next if layer.skip_layer?(layer)
 
           # we don't need to use the full metric name for scoped metrics as we
           # only display metrics aggregrated by type, just use "ActiveRecord"

--- a/lib/scout_apm/layer_converters/job_converter.rb
+++ b/lib/scout_apm/layer_converters/job_converter.rb
@@ -57,7 +57,7 @@ module ScoutApm
         walker.walk do |layer|
           next if layer == job_layer
           next if layer == queue_layer
-          next if layer.skip_layer?(layer)
+          next if skip_layer?(layer)
 
           # we don't need to use the full metric name for scoped metrics as we
           # only display metrics aggregrated by type, just use "ActiveRecord"

--- a/lib/scout_apm/layer_converters/metric_converter.rb
+++ b/lib/scout_apm/layer_converters/metric_converter.rb
@@ -21,7 +21,7 @@ module ScoutApm
         metric_hash = Hash.new
 
         walker.walk do |layer|
-          next if layer.annotations[:ignorable]
+          next if skip_layer?(layer)
 
           meta_options = if layer == scope_layer # We don't scope the controller under itself
                           {}


### PR DESCRIPTION
Most Layer objects are leaf nodes (no children), with no annotations, so
avoid creating the empty data structures to hold data that will likely
never arrive.

This will lower the CPU overhead a small amount (no need to call then destroy an
extra set of objects), and will chip away at any memory overhead as
well, especially on long-running requests that create many Layer objects