### PR TITLE
Add and wireup a LayerChildrenSet to cap the number of children for a layer

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -27,6 +27,8 @@ require 'scout_apm/version'
 
 require 'scout_apm/tracked_request'
 require 'scout_apm/layer'
+require 'scout_apm/merged_layer'
+require 'scout_apm/layer_children_set'
 require 'scout_apm/request_manager'
 require 'scout_apm/call_set'
 

--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -27,7 +27,7 @@ require 'scout_apm/version'
 
 require 'scout_apm/tracked_request'
 require 'scout_apm/layer'
-require 'scout_apm/merged_layer'
+require 'scout_apm/limited_layer'
 require 'scout_apm/layer_children_set'
 require 'scout_apm/request_manager'
 require 'scout_apm/call_set'

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -154,6 +154,7 @@ module ScoutApm
         map { |child| child.total_call_time }.
         inject(0) { |sum, time| sum + time }
     end
+    private :child_time
 
     ######################################
     # Allocation Calculations
@@ -179,5 +180,6 @@ module ScoutApm
         map { |child| child.total_allocations }.
         inject(0) { |sum, obj| sum + obj }
     end
+    private :child_allocations
   end
 end

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -22,7 +22,7 @@ module ScoutApm
     #
     # TODO: Check callers for compatibility w/ nil to avoid making an empty array
     def children
-      @children || []
+      @children || LayerChildrenSet.new
     end
 
     # Time objects recording the start & stop times of this layer
@@ -62,7 +62,7 @@ module ScoutApm
     end
 
     def add_child(child)
-      @children ||= []
+      @children ||= LayerChildrenSet.new
       @children << child
     end
 

--- a/lib/scout_apm/layer_children_set.rb
+++ b/lib/scout_apm/layer_children_set.rb
@@ -19,7 +19,7 @@ module ScoutApm
 
     # By default, how many unique children of a type do we store before
     # flipping over to storing only aggregate info.
-    DEFAULT_UNIQUE_CUTOFF = 1000
+    DEFAULT_UNIQUE_CUTOFF = 2000
     attr_reader :unique_cutoff
 
     # The Set of children objects

--- a/lib/scout_apm/layer_children_set.rb
+++ b/lib/scout_apm/layer_children_set.rb
@@ -1,0 +1,66 @@
+module ScoutApm
+  # A set of children records for any given Layer.  This implements some
+  # rate-limiting logic.
+  #
+  # When the set of children is small, keep them unique
+  # When the set of children gets large enough, stop keeping details
+  #
+  # The next optimization, which is not yet implemented:
+  #   when the set of children gets larger, attempt to merge them without data loss
+  class LayerChildrenSet
+    include Enumerable
+
+    # By default, how many unique children of a type do we store before
+    # flipping over to storing only aggregate info.
+    DEFAULT_UNIQUE_CUTOFF = 1000
+    attr_reader :unique_cutoff
+
+    # The Set of children objects
+    attr_reader :children
+    private :children
+
+
+    def initialize(unique_cutoff = DEFAULT_UNIQUE_CUTOFF)
+      @children = Hash.new { |hash, key| hash[key] = Set.new }
+      @merged_layers = nil # populated when needed
+      @unique_cutoff = unique_cutoff
+    end
+
+    # Add a new layer into this set
+    # Only add completed layers - otherwise this will collect up incorrect info
+    # into the created MergedLayer, since it will "freeze" any current data for
+    # total_call_time and similar methods.
+    def <<(child)
+      metric_type = child.type
+      set = children[metric_type]
+
+      if set.size > unique_cutoff
+        # find merged_layer
+        @merged_layers || init_merged_layers
+        @merged_layers[metric_type].absorb(child)
+      else
+        # we have space just add it
+        set << child
+      end
+    end
+
+    def each
+      children.each do |_type, set|
+        set.each do |child_layer|
+          yield child_layer
+        end
+      end
+
+      if @merged_layers
+        @merged_layers.each do |_type, merged_layer|
+          yield merged_layer
+        end
+      end
+    end
+
+    # hold off initializing this until we know we need it
+    def init_merged_layers
+      @merged_layers = Hash.new { |hash, key| hash[key] = MergedLayer.new(key) }
+    end
+  end
+end

--- a/lib/scout_apm/layer_children_set.rb
+++ b/lib/scout_apm/layer_children_set.rb
@@ -2,6 +2,13 @@ module ScoutApm
   # A set of children records for any given Layer.  This implements some
   # rate-limiting logic.
   #
+  # We store the first `unique_cutoff` count of each layer type. So if cutoff
+  # is 1000, we'd store 1000 HTTP layers, and 1000 ActiveRecord calls, and 1000
+  # of each other layer type. After that, make a LimitedLayer object and store
+  # only aggregate counts and times of future layers of that type. (So the
+  # 1001st an onward of ActiveRecord would get only aggregate times, and
+  # counts, without any detail about the SQL called)
+  #
   # When the set of children is small, keep them unique
   # When the set of children gets large enough, stop keeping details
   #
@@ -19,25 +26,24 @@ module ScoutApm
     attr_reader :children
     private :children
 
-
     def initialize(unique_cutoff = DEFAULT_UNIQUE_CUTOFF)
       @children = Hash.new { |hash, key| hash[key] = Set.new }
-      @merged_layers = nil # populated when needed
+      @limited_layers = nil # populated when needed
       @unique_cutoff = unique_cutoff
     end
 
     # Add a new layer into this set
     # Only add completed layers - otherwise this will collect up incorrect info
-    # into the created MergedLayer, since it will "freeze" any current data for
+    # into the created LimitedLayer, since it will "freeze" any current data for
     # total_call_time and similar methods.
     def <<(child)
       metric_type = child.type
       set = children[metric_type]
 
-      if set.size > unique_cutoff
-        # find merged_layer
-        @merged_layers || init_merged_layers
-        @merged_layers[metric_type].absorb(child)
+      if set.size >= unique_cutoff
+        # find limited_layer
+        @limited_layers || init_limited_layers
+        @limited_layers[metric_type].absorb(child)
       else
         # we have space just add it
         set << child
@@ -51,16 +57,16 @@ module ScoutApm
         end
       end
 
-      if @merged_layers
-        @merged_layers.each do |_type, merged_layer|
-          yield merged_layer
+      if @limited_layers
+        @limited_layers.each do |_type, limited_layer|
+          yield limited_layer
         end
       end
     end
 
     # hold off initializing this until we know we need it
-    def init_merged_layers
-      @merged_layers = Hash.new { |hash, key| hash[key] = MergedLayer.new(key) }
+    def init_limited_layers
+      @limited_layers ||= Hash.new { |hash, key| hash[key] = LimitedLayer.new(key) }
     end
   end
 end

--- a/lib/scout_apm/layer_converters/converter_base.rb
+++ b/lib/scout_apm/layer_converters/converter_base.rb
@@ -192,7 +192,7 @@ module ScoutApm
         stat = allocation_metric_hash[meta]
         stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
 
-        if MergedLayer === layer
+        if LimitedLayer === layer
           metric_hash[meta].call_count = layer.count
           allocation_metric_hash[meta].call_count = layer.count
         end

--- a/lib/scout_apm/layer_converters/converter_base.rb
+++ b/lib/scout_apm/layer_converters/converter_base.rb
@@ -191,6 +191,11 @@ module ScoutApm
         # allocations
         stat = allocation_metric_hash[meta]
         stat.update!(layer.total_allocations, layer.total_exclusive_allocations)
+
+        if MergedLayer === layer
+          metric_hash[meta].call_count = layer.count
+          allocation_metric_hash[meta].call_count = layer.count
+        end
       end
 
       # Merged Metric - no specifics, just sum up by type (ActiveRecord, View, HTTP, etc)

--- a/lib/scout_apm/limited_layer.rb
+++ b/lib/scout_apm/limited_layer.rb
@@ -1,10 +1,10 @@
 module ScoutApm
-  # A MergedLayer is a lossy-compression approach to fall back on once we max out
+  # A LimitedLayer is a lossy-compression approach to fall back on once we max out
   # the number of detailed layer objects we store.  See LayerChildrenSet for the
   # logic on when that change over happens
   #
   # QUESTION: What do we do if we attempt to merge an item that has children?
-  class MergedLayer
+  class LimitedLayer
     attr_reader :type
 
     def initialize(type)
@@ -51,7 +51,7 @@ module ScoutApm
     # removed, and the new type & name split should be enforced through the
     # app.
     def legacy_metric_name
-      "#{type}/Merged"
+      "#{type}/Limited"
     end
 
     def children
@@ -63,7 +63,7 @@ module ScoutApm
     end
 
     def to_s
-      "<MergedLayer type=#{type} count=#{count}>"
+      "<LimitedLayer type=#{type} count=#{count}>"
     end
 
     ######################################################
@@ -83,40 +83,40 @@ module ScoutApm
 
 
     #######################################################################
-    #  Many methods don't make any sense on a merged layer. Raise errors  #
+    #  Many methods don't make any sense on a limited layer. Raise errors  #
     #  aggressively for now to detect mistaken calls                      #
     #######################################################################
 
     def add_child
-      raise "Should never call add_child on a merged_layer"
+      raise "Should never call add_child on a limited_layer"
     end
 
     def record_stop_time!(*)
-      raise "Should never call record_stop_time! on a merged_layer"
+      raise "Should never call record_stop_time! on a limited_layer"
     end
 
     def record_allocations!
-      raise "Should never call record_allocations! on a merged_layer"
+      raise "Should never call record_allocations! on a limited_layer"
     end
 
     def desc=(*)
-      raise "Should never call desc on a merged_layer"
+      raise "Should never call desc on a limited_layer"
     end
 
     def annotate_layer(*)
-      raise "Should never call annotate_layer on a merged_layer"
+      raise "Should never call annotate_layer on a limited_layer"
     end
 
     def subscopable!
-      raise "Should never call subscopable! on a merged_layer"
+      raise "Should never call subscopable! on a limited_layer"
     end
 
     def capture_backtrace!
-      raise "Should never call capture_backtrace on a merged_layer"
+      raise "Should never call capture_backtrace on a limited_layer"
     end
 
     def caller_array
-      raise "Should never call caller_array on a merged_layer"
+      raise "Should never call caller_array on a limited_layer"
     end
   end
 end

--- a/lib/scout_apm/merged_layer.rb
+++ b/lib/scout_apm/merged_layer.rb
@@ -1,124 +1,122 @@
 module ScoutApm
-  module Layers
-    # A MergedLayer is a lossy-compression approach to fall back on once we max out
-    # the number of detailed layer objects we store.  See LayerChildrenSet for the
-    # logic on when that change over happens
-    #
-    # QUESTION: What do we do if we attempt to merge an item that has children?
-    class MergedLayer
-      attr_reader :type
+  # A MergedLayer is a lossy-compression approach to fall back on once we max out
+  # the number of detailed layer objects we store.  See LayerChildrenSet for the
+  # logic on when that change over happens
+  #
+  # QUESTION: What do we do if we attempt to merge an item that has children?
+  class MergedLayer
+    attr_reader :type
 
-      def initialize(type)
-        @type = type
+    def initialize(type)
+      @type = type
 
-        @total_call_time = 0
-        @total_exclusive_time = 0
-        @total_allocations = 0
-        @total_exclusive_allocations = 0
-        @total_layers = 0
-      end
+      @total_call_time = 0
+      @total_exclusive_time = 0
+      @total_allocations = 0
+      @total_exclusive_allocations = 0
+      @total_layers = 0
+    end
 
-      def absorb(layer)
-        @total_layers += 1
+    def absorb(layer)
+      @total_layers += 1
 
-        @total_call_time += layer.total_call_time
-        @total_exclusive_time += layer.total_exclusive_time
+      @total_call_time += layer.total_call_time
+      @total_exclusive_time += layer.total_exclusive_time
 
-        @total_allocations += layer.total_allocations
-        @total_exclusive_allocations += layer.total_exclusive_allocations
-      end
+      @total_allocations += layer.total_allocations
+      @total_exclusive_allocations += layer.total_exclusive_allocations
+    end
 
-      def total_call_time
-        @total_call_time
-      end
+    def total_call_time
+      @total_call_time
+    end
 
-      def total_exclusive_time
-        @total_exclusive_time
-      end
+    def total_exclusive_time
+      @total_exclusive_time
+    end
 
-      def total_allocations
-        @total_allocations
-      end
+    def total_allocations
+      @total_allocations
+    end
 
-      def total_exclusive_allocations
-        @total_exclusive_allocations
-      end
+    def total_exclusive_allocations
+      @total_exclusive_allocations
+    end
 
-      def count
-        @total_layers
-      end
+    def count
+      @total_layers
+    end
 
-      # This is the old style name. This function is used for now, but should be
-      # removed, and the new type & name split should be enforced through the
-      # app.
-      def legacy_metric_name
-        "#{type}/Merged"
-      end
+    # This is the old style name. This function is used for now, but should be
+    # removed, and the new type & name split should be enforced through the
+    # app.
+    def legacy_metric_name
+      "#{type}/Merged"
+    end
 
-      def children
-        Set.new
-      end
+    def children
+      Set.new
+    end
 
-      def annotations
-        nil
-      end
+    def annotations
+      nil
+    end
 
-      def to_s
-        "<MergedLayer type=#{type} count=#{count}>"
-      end
+    def to_s
+      "<MergedLayer type=#{type} count=#{count}>"
+    end
 
-      ######################################################
-      #  Stub out some methods with static default values  #
-      ######################################################
-      def subscopable?
-        false
-      end
+    ######################################################
+    #  Stub out some methods with static default values  #
+    ######################################################
+    def subscopable?
+      false
+    end
 
-      def desc
-        nil
-      end
+    def desc
+      nil
+    end
 
-      def backtrace
-        nil
-      end
+    def backtrace
+      nil
+    end
 
 
-      #######################################################################
-      #  Many methods don't make any sense on a merged layer. Raise errors  #
-      #  aggressively for now to detect mistaken calls                      #
-      #######################################################################
+    #######################################################################
+    #  Many methods don't make any sense on a merged layer. Raise errors  #
+    #  aggressively for now to detect mistaken calls                      #
+    #######################################################################
 
-      def add_child
-        raise "Should never call add_child on a merged_layer"
-      end
+    def add_child
+      raise "Should never call add_child on a merged_layer"
+    end
 
-      def record_stop_time!(*)
-        raise "Should never call record_stop_time! on a merged_layer"
-      end
+    def record_stop_time!(*)
+      raise "Should never call record_stop_time! on a merged_layer"
+    end
 
-      def record_allocations!
-        raise "Should never call record_allocations! on a merged_layer"
-      end
+    def record_allocations!
+      raise "Should never call record_allocations! on a merged_layer"
+    end
 
-      def desc=(*)
-        raise "Should never call desc on a merged_layer"
-      end
+    def desc=(*)
+      raise "Should never call desc on a merged_layer"
+    end
 
-      def annotate_layer(*)
-        raise "Should never call annotate_layer on a merged_layer"
-      end
+    def annotate_layer(*)
+      raise "Should never call annotate_layer on a merged_layer"
+    end
 
-      def subscopable!
-        raise "Should never call subscopable! on a merged_layer"
-      end
+    def subscopable!
+      raise "Should never call subscopable! on a merged_layer"
+    end
 
-      def capture_backtrace!
-        raise "Should never call capture_backtrace on a merged_layer"
-      end
+    def capture_backtrace!
+      raise "Should never call capture_backtrace on a merged_layer"
+    end
 
-      def caller_array
-        raise "Should never call caller_array on a merged_layer"
-      end
+    def caller_array
+      raise "Should never call caller_array on a merged_layer"
     end
   end
 end

--- a/lib/scout_apm/merged_layer.rb
+++ b/lib/scout_apm/merged_layer.rb
@@ -1,0 +1,124 @@
+module ScoutApm
+  module Layers
+    # A MergedLayer is a lossy-compression approach to fall back on once we max out
+    # the number of detailed layer objects we store.  See LayerChildrenSet for the
+    # logic on when that change over happens
+    #
+    # QUESTION: What do we do if we attempt to merge an item that has children?
+    class MergedLayer
+      attr_reader :type
+
+      def initialize(type)
+        @type = type
+
+        @total_call_time = 0
+        @total_exclusive_time = 0
+        @total_allocations = 0
+        @total_exclusive_allocations = 0
+        @total_layers = 0
+      end
+
+      def absorb(layer)
+        @total_layers += 1
+
+        @total_call_time += layer.total_call_time
+        @total_exclusive_time += layer.total_exclusive_time
+
+        @total_allocations += layer.total_allocations
+        @total_exclusive_allocations += layer.total_exclusive_allocations
+      end
+
+      def total_call_time
+        @total_call_time
+      end
+
+      def total_exclusive_time
+        @total_exclusive_time
+      end
+
+      def total_allocations
+        @total_allocations
+      end
+
+      def total_exclusive_allocations
+        @total_exclusive_allocations
+      end
+
+      def count
+        @total_layers
+      end
+
+      # This is the old style name. This function is used for now, but should be
+      # removed, and the new type & name split should be enforced through the
+      # app.
+      def legacy_metric_name
+        "#{type}/Merged"
+      end
+
+      def children
+        Set.new
+      end
+
+      def annotations
+        nil
+      end
+
+      def to_s
+        "<MergedLayer type=#{type} count=#{count}>"
+      end
+
+      ######################################################
+      #  Stub out some methods with static default values  #
+      ######################################################
+      def subscopable?
+        false
+      end
+
+      def desc
+        nil
+      end
+
+      def backtrace
+        nil
+      end
+
+
+      #######################################################################
+      #  Many methods don't make any sense on a merged layer. Raise errors  #
+      #  aggressively for now to detect mistaken calls                      #
+      #######################################################################
+
+      def add_child
+        raise "Should never call add_child on a merged_layer"
+      end
+
+      def record_stop_time!(*)
+        raise "Should never call record_stop_time! on a merged_layer"
+      end
+
+      def record_allocations!
+        raise "Should never call record_allocations! on a merged_layer"
+      end
+
+      def desc=(*)
+        raise "Should never call desc on a merged_layer"
+      end
+
+      def annotate_layer(*)
+        raise "Should never call annotate_layer on a merged_layer"
+      end
+
+      def subscopable!
+        raise "Should never call subscopable! on a merged_layer"
+      end
+
+      def capture_backtrace!
+        raise "Should never call capture_backtrace on a merged_layer"
+      end
+
+      def caller_array
+        raise "Should never call caller_array on a merged_layer"
+      end
+    end
+  end
+end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -62,7 +62,6 @@ module ScoutApm
       return ignoring_start_layer if ignoring_request?
 
       start_request(layer) unless @root_layer
-      @layers[-1].add_child(layer) if @layers.any?
       @layers.push(layer)
     end
 
@@ -85,6 +84,8 @@ module ScoutApm
 
       layer.record_stop_time!
       layer.record_allocations!
+
+      @layers[-1].add_child(layer) if @layers.any?
 
       # This must be called before checking if a backtrace should be collected as the call count influences our capture logic.
       # We call `#update_call_counts in stop layer to ensure the layer has a final desc. Layer#desc is updated during the AR instrumentation flow.

--- a/test/unit/layer_children_set_test.rb
+++ b/test/unit/layer_children_set_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+require 'scout_apm/layer_children_set'
+
+class LayerChildrenSetTest < Minitest::Test
+  SET = ScoutApm::LayerChildrenSet
+
+  def test_limit_default
+    assert_equal SET::DEFAULT_UNIQUE_CUTOFF, SET.new.unique_cutoff
+  end
+
+  # Add 5, make sure they're all in the children list we get back.
+  def test_add_layer_before_limit
+    s = SET.new(5)
+
+    5.times do
+      s << make_layer("LayerType", "LayerName")
+    end
+
+    children = s.to_a
+    assert_equal 5, children.size
+
+    # Don't care about order
+    (0..4).each do |i|
+      assert children.include?(lookup_layer(i))
+    end
+  end
+
+  def test_add_layer_after_limit
+    s = SET.new(5)
+
+    10.times do
+      s << make_layer("LayerType", "LayerName")
+    end
+
+    children = s.to_a
+    # 6 = 5 real ones + 1 merged.
+    assert_equal 6, children.size
+
+    # Don't care about order
+    (0..4).each do |i|
+      assert children.include?(lookup_layer(i))
+    end
+
+    # Don't care about order
+    (5..9).each do |i|
+      assert ! children.include?(lookup_layer(i))
+    end
+
+    limited_layer = children.last
+    assert_equal ScoutApm::LimitedLayer, limited_layer.class
+    assert_equal 5, limited_layer.count
+  end
+
+  def test_add_layer_with_different_type_after_limit
+    s = SET.new(5)
+
+    # Add 20 items
+    10.times do
+      s << make_layer("LayerType", "LayerName")
+      s << make_layer("DifferentLayerType", "LayerName")
+    end
+
+    children = s.to_a
+
+    # Tyo types, so 2 distinct limitdlayer objects
+    limited_layers = children.select{ |l| ScoutApm::LimitedLayer === l }
+    assert_equal 2, limited_layers.length
+
+    # 5 unchanged children each for the two layer types, plus the 2 limitd when each overran their limit
+    assert_equal 12, children.length
+    limited_layers.each { |ml| assert_equal 5, ml.count }
+  end
+
+  #############
+  #  Helpers  #
+  #############
+
+  def make_layer(type, name)
+    @made_layers ||= []
+    l = ScoutApm::Layer.new(type, name)
+    @made_layers << l
+    l
+  end
+
+  def lookup_layer(i)
+    @made_layers[i]
+  end
+end

--- a/test/unit/limited_layer_test.rb
+++ b/test/unit/limited_layer_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+require 'ostruct'
+
+class LimitedLayerTest < Minitest::Test
+
+  def test_counts_while_absorbing
+    ll = ScoutApm::LimitedLayer.new("ActiveRecord")
+    assert_equal 0, ll.count
+
+    ll.absorb faux_layer("ActiveRecord", "User#Find", 2, 1, 200, 100)
+    assert_equal 1, ll.count
+
+    ll.absorb faux_layer("ActiveRecord", "User#Find", 2, 1, 200, 100)
+    assert_equal 2, ll.count
+  end
+
+  def test_sums_values_while_absorbing
+    ll = ScoutApm::LimitedLayer.new("ActiveRecord")
+
+    ll.absorb faux_layer("ActiveRecord", "User#Find", 2, 1, 200, 100)
+    assert_equal 1, ll.total_exclusive_time
+    assert_equal 2, ll.total_call_time
+    assert_equal 100, ll.total_exclusive_allocations
+    assert_equal 200, ll.total_allocations
+
+
+    ll.absorb faux_layer("ActiveRecord", "User#Find", 4, 3, 400, 300)
+    assert_equal 4, ll.total_exclusive_time           # 3 + 1
+    assert_equal 6, ll.total_call_time                # 4 + 2
+    assert_equal 400, ll.total_exclusive_allocations  # 300 + 100
+    assert_equal 600, ll.total_allocations            # 400 + 200
+  end
+
+  def test_the_name
+    ll = ScoutApm::LimitedLayer.new("ActiveRecord")
+    assert_equal "ActiveRecord/Limited", ll.legacy_metric_name
+  end
+
+  #############
+  #  Helpers  #
+  #############
+
+  def faux_layer(type, name, tct, tet, a_tct, a_tet)
+    OpenStruct.new(
+      :type => type,
+      :name => name,
+      :total_call_time => tct,
+      :total_exclusive_time => tet,
+      :total_allocations => a_tct,
+      :total_exclusive_allocations => a_tet,
+    )
+  end
+end


### PR DESCRIPTION
This lets us cap the number of children any given layer can accumulate,
then it starts combining them together.

The limit is per type (HTTP, ActiveRecord, View...), and currently is at
1000.   That number is arbitrary, and not based on any research.  Likely it
will change or get larger as we figure out the right balance.

The reason for this is to limit the number of Layer objects we store in ram
over the course of a request. In long running jobs in particular, the
number of layers encountered can get very very large, and even though they
are pretty small objects on their own, the weight of them can add up.  This
approach provides a safety valve to prevent our memory use going up over a
long trace.

Anything going over the limit gets bucketed into a single `HTTP/Merged`
bucket, which shows up as its own line-item in the trace, so overall times
and counts are not lost.