### PR TITLE
Refactor DevTrace's middleware

### DIFF
--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -120,6 +120,8 @@ module ScoutApm
       init_logger
       logger.info "Attempting to start Scout Agent [#{ScoutApm::VERSION}] on [#{environment.hostname}]"
 
+      @config.log_settings
+
       @ignored_uris = ScoutApm::IgnoredUris.new(config.value('ignore'))
 
       load_instruments if should_load_instruments?(options)

--- a/lib/scout_apm/instant/middleware.rb
+++ b/lib/scout_apm/instant/middleware.rb
@@ -5,6 +5,11 @@ module ScoutApm
     class Page
       def initialize(html)
         @html = html
+
+        if html.is_a?(Array)
+          @html = html.inject("") { |memo, str| memo + str }
+        end
+
         @to_add_to_head = []
         @to_add_to_body = []
       end
@@ -45,66 +50,185 @@ module ScoutApm
       end
 
       def call(env)
-        status, headers, response = @app.call(env)
-        path, content_type = env['PATH_INFO'], headers['Content-Type']
-        if ScoutApm::Agent.instance.config.value('dev_trace')
-          if response.respond_to?(:body)
-            req = ScoutApm::RequestManager.lookup
-
-            return [status, headers, response] if req.ignoring_request?
-
-            slow_converter = LayerConverters::SlowRequestConverter.new(req)
-            trace = slow_converter.call
-            if trace
-              metadata = {
-                  :app_root      => ScoutApm::Environment.instance.root.to_s,
-                  :unique_id     => env['action_dispatch.request_id'], # note, this is a different unique_id than what "normal" payloads use
-                  :agent_version => ScoutApm::VERSION,
-                  :platform      => "ruby",
-              }
-              hash = ScoutApm::Serializers::PayloadSerializerToJson.rearrange_slow_transaction(trace)
-              hash.merge!(:metadata => metadata)
-              payload = ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(hash)
-
-              if env['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest' || content_type.include?("application/json")
-                ScoutApm::Agent.instance.logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body. This is either AJAX or JSON. Path=#{path}; ContentType=#{content_type}")
-                # Add the payload as a header if it's an AJAX call or JSON
-                headers['X-scoutapminstant'] = payload
-                [status, headers, response]
-              else
-                # otherwise, attempt to add it inline in the page, along with the appropriate JS & CSS. Note, if page doesn't have a head or body,
-                #duration = (req.root_layer.total_call_time*1000).to_i
-                apm_host=ScoutApm::Agent.instance.config.value("direct_host")
-                page = ScoutApm::Instant::Page.new(response.body)
-                page.add_to_head(ScoutApm::Instant::Util.read_asset("xmlhttp_instrumentation.html")) # This monkey-patches XMLHttpRequest. It could possibly be part of the main scout_instant.js too. Putting it here so it runs as soon as possible.
-                page.add_to_head("<link href='#{apm_host}/instant/scout_instant.css?cachebust=#{Time.now.to_i}' media='all' rel='stylesheet' />")
-                page.add_to_body("<script src='#{apm_host}/instant/scout_instant.js?cachebust=#{Time.now.to_i}'></script>")
-                page.add_to_body("<script>var scoutInstantPageTrace=#{payload};window.scoutInstant=window.scoutInstant('#{apm_host}', scoutInstantPageTrace)</script>")
-
-                if response.is_a?(ActionDispatch::Response)
-                  ScoutApm::Agent.instance.logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body. This appears to be an HTML page and an ActionDispatch::Response. Path=#{path}; ContentType=#{content_type}")
-                  # preserve the ActionDispatch::Response when applicable
-                  response.body=[page.res]
-                  [status, headers, response]
-                else
-                  ScoutApm::Agent.instance.logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body. This appears to be an HTML page but not an ActionDispatch::Response. Path=#{path}; ContentType=#{content_type}")
-                  # otherwise, just return an array
-                  [status, headers, [page.res]]
-                end
-              end
-            else
-              ScoutApm::Agent.instance.logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body, but no trace was found. Path=#{path}; ContentType=#{content_type}")
-              [status, headers, response]
-            end
-          else
-            # don't log anything here - this is the path for all assets served in development, and the log would get noisy
-            [status, headers, response]
-          end
-        else
-          ScoutApm::Agent.instance.logger.debug("DevTrace: isn't activated via config. Try: SCOUT_DEV_TRACE=true rails server")
-          [status, headers, response]
+        rack_response = @app.call(env)
+        begin
+          DevTraceResponseManipulator.new(env, rack_response).call
+        rescue => e
+          ScoutApm::Agent.instance.logger.debug("DevTrace: Raised an exception: #{e.message}, #{e.backtrace}")
+          rack_response
         end
       end
+    end
+
+    class DevTraceResponseManipulator
+      attr_reader :rack_response
+      attr_reader :rack_status, :rack_headers, :rack_body
+      attr_reader :env
+
+      def initialize(env, rack_response)
+        @env = env
+        @rack_response = rack_response
+
+        @rack_status = rack_response[0]
+        @rack_headers = rack_response[1]
+        @rack_body = rack_response[2]
+      end
+
+      def call
+        return rack_response unless preconditions_met?
+
+        if ajax_request?
+          ScoutApm::Agent.instance.logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body. This is either AJAX or JSON. Path=#{path}; ContentType=#{content_type}")
+          adjust_ajax_header
+        else
+          adjust_html_response
+        end
+
+        rebuild_rack_response
+      end
+
+      ###########################
+      #  Precondition checking  #
+      ###########################
+
+      def preconditions_met?
+        if dev_trace_disabled?
+          logger.debug("DevTrace: isn't activated via config. Try: SCOUT_DEV_TRACE=true rails server")
+          return false
+        end
+
+        # Don't attempt to instrument assets.
+        # Don't log this case, since it would be very noisy
+        logger.debug("DevTrace: dev asset ignored") and return false if development_asset?
+
+        # If we didn't have a tracked_request object, or we explicitly ignored
+        # this request, don't do any work.
+        logger.debug("DevTrace: no tracked request") and return false if tracked_request.nil? || tracked_request.ignoring_request?
+
+        # If we didn't get a trace, we can't show a trace...
+        if trace.nil?
+          logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body, but no trace was found. Path=#{path}; ContentType=#{content_type}")
+          return false
+        end
+
+        true
+      end
+
+      def dev_trace_disabled?
+        ! ScoutApm::Agent.instance.config.value('dev_trace')
+      end
+
+      ########################
+      #  Response Injection  #
+      ########################
+
+      def rebuild_rack_response
+        [rack_status, rack_headers, rack_body]
+      end
+
+      def adjust_ajax_header
+        rack_headers['X-scoutapminstant'] = payload
+      end
+
+      def adjust_html_response
+        case true
+        when rails_response?      then  adjust_rails_response
+        when rack_proxy_response? then  adjust_rack_proxy_response
+        else
+          # No action taken, we only adjust if we know exactly what we have.
+        end
+      end
+
+      def rails_response?
+        rack_body.is_a?(ActionDispatch::Response)
+      end
+
+      def rack_proxy_response?
+        rack_body.is_a?(Rack::BodyProxy)
+      end
+
+      # Preserve the ActionDispatch::Response object we're working with
+      def adjust_rails_response
+        logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body. This appears to be an HTML page and an ActionDispatch::Response. Path=#{path}; ContentType=#{content_type}")
+        rack_body.body = [ html_manipulator.res ]
+      end
+
+      def adjust_rack_proxy_response
+        logger.debug("DevTrace: in middleware, dev_trace is active, and response has a body. This appears to be an HTML page and an Rack::BodyProxy. Path=#{path}; ContentType=#{content_type}")
+        @rack_body = [ html_manipulator.res ]
+        @rack_headers.delete("Content-Length")
+      end
+
+      def html_manipulator
+        @html_manipulator ||=
+          begin
+            page = ScoutApm::Instant::Page.new(rack_body.body)
+
+            # This monkey-patches XMLHttpRequest. It could possibly be part of the main scout_instant.js too. Putting it here so it runs as soon as possible.
+            page.add_to_head(ScoutApm::Instant::Util.read_asset("xmlhttp_instrumentation.html"))
+
+            # Add a link to CSS, then JS
+            page.add_to_head("<link href='#{apm_host}/instant/scout_instant.css?cachebust=#{Time.now.to_i}' media='all' rel='stylesheet' />")
+            page.add_to_body("<script src='#{apm_host}/instant/scout_instant.js?cachebust=#{Time.now.to_i}'></script>")
+            page.add_to_body("<script>var scoutInstantPageTrace=#{payload};window.scoutInstant=window.scoutInstant('#{apm_host}', scoutInstantPageTrace)</script>")
+
+            page
+          end
+      end
+
+      def ajax_request?
+        env['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest' || content_type.include?("application/json")
+      end
+
+      def development_asset?
+        !rack_body.respond_to?(:body)
+      end
+
+      def path
+        env['PATH_INFO']
+      end
+
+      def content_type
+        rack_headers['Content-Type']
+      end
+
+      ##############################
+      #  APM Helpers & Shorthands  #
+      ##############################
+
+      def logger
+        ScoutApm::Agent.instance.logger
+      end
+
+      def tracked_request
+        @tracked_request ||= ScoutApm::RequestManager.lookup
+      end
+
+      def apm_host
+        ScoutApm::Agent.instance.config.value("direct_host")
+      end
+
+      def trace
+        @trace ||= LayerConverters::SlowRequestConverter.new(tracked_request).call
+      end
+
+      def payload
+        @payload ||=
+          begin
+            metadata = {
+              :app_root      => ScoutApm::Environment.instance.root.to_s,
+              :unique_id     => env['action_dispatch.request_id'], # note, this is a different unique_id than what "normal" payloads use
+              :agent_version => ScoutApm::VERSION,
+              :platform      => "ruby",
+            }
+
+            hash = ScoutApm::Serializers::PayloadSerializerToJson.
+              rearrange_slow_transaction(trace).
+              merge!(:metadata => metadata)
+            ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(hash)
+          end
+      end
+
     end
   end
 end


### PR DESCRIPTION
* Much cleaner, split into different methods.
* Safer - fallback rescue should handle most situations
* Now works with Grape endpoints that return HTML but not ActionDispatch::Response objects