### PR TITLE
Add a debug log of all config settings & where they came from

### DIFF
--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -120,6 +120,8 @@ module ScoutApm
       init_logger
       logger.info "Attempting to start Scout Agent [#{ScoutApm::VERSION}] on [#{environment.hostname}]"
 
+      @config.log_settings
+
       @ignored_uris = ScoutApm::IgnoredUris.new(config.value('ignore'))
 
       load_instruments if should_load_instruments?(options)


### PR DESCRIPTION
This dumps a list of all settings and where they came from (Defaults, ConfigFile, Environment...), when debug logging is enabled.

To enable debug logging, start your application server with an environment variable `SCOUT_LOG_LEVEL=debug` or set `log_level: debug` in the appropriate section of `scout_apm.yml`.