### PR TITLE
Config option `detailed_middleware` to monitor each middleware layer

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -75,7 +75,7 @@ require 'scout_apm/instruments/active_record'
 require 'scout_apm/instruments/action_controller_rails_2'
 require 'scout_apm/instruments/action_controller_rails_3_rails4'
 require 'scout_apm/instruments/middleware_summary'
-# require 'scout_apm/instruments/middleware_detailed' # Currently disabled functionality, see the file for details.
+require 'scout_apm/instruments/middleware_detailed' # Disabled by default, see the file for more details
 require 'scout_apm/instruments/rails_router'
 require 'scout_apm/instruments/grape'
 require 'scout_apm/instruments/sinatra'

--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -287,8 +287,13 @@ module ScoutApm
         install_instrument(ScoutApm::Instruments::ActionControllerRails2)
       when :rails3_or_4 then
         install_instrument(ScoutApm::Instruments::ActionControllerRails3Rails4)
-        install_instrument(ScoutApm::Instruments::MiddlewareSummary)
         install_instrument(ScoutApm::Instruments::RailsRouter)
+
+        if config.value("detailed_middleware")
+          install_instrument(ScoutApm::Instruments::MiddlewareDetailed)
+        else
+          install_instrument(ScoutApm::Instruments::MiddlewareSummary)
+        end
       end
 
       install_instrument(ScoutApm::Instruments::ActiveRecord)

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -37,6 +37,7 @@ module ScoutApm
         'compress_payload',
         'config_file',
         'data_file',
+        'detailed_middleware',
         'dev_trace',
         'direct_host',
         'disabled_instruments',
@@ -45,8 +46,8 @@ module ScoutApm
         'hostname',
         'ignore',
         'key',
-        'log_level',
         'log_file_path',
+        'log_level',
         'monitor',
         'name',
         'profile',
@@ -129,6 +130,7 @@ module ScoutApm
       "monitor"                => BooleanCoercion.new,
       "enable_background_jobs" => BooleanCoercion.new,
       "dev_trace"              => BooleanCoercion.new,
+      "detailed_middleware"    => BooleanCoercion.new,
       "ignore"                 => JsonCoercion.new,
     }
 
@@ -203,6 +205,7 @@ module ScoutApm
     class ConfigDefaults
       DEFAULTS = {
         'compress_payload'       => true,
+        'detailed_middleware'    => false,
         'dev_trace'              => false,
         'direct_host'            => 'https://apm.scoutapp.com',
         'disabled_instruments'   => [],

--- a/lib/scout_apm/instruments/middleware_detailed.rb
+++ b/lib/scout_apm/instruments/middleware_detailed.rb
@@ -1,13 +1,11 @@
 # Inserts a new middleware between each actual middleware in the application,
 # so as to trace the time for each one.
 #
-# Currently disabled due to the overhead of this approach (~10-15ms per request
-# in practice).  Instead, middleware as a whole are instrumented via the
-# MiddlewareSummary class.
+# Currently disabled by default due to the overhead of this approach (~10-15ms
+# per request in practice).  Instead, middleware as a whole are instrumented
+# via the MiddlewareSummary class.
 #
-# There will likely be a configuration flag to turn this on in favor of the
-# summary tracing in a future version of the agent, but this is not yet
-# implemented.
+# Turn this on with the configuration setting `detailed_middleware` set to true
 module ScoutApm
   module Instruments
     class MiddlewareDetailed


### PR DESCRIPTION
The detailed_middleware option switches from a general measurement of
all middlewares to a per-middleware measurement. This has an additional
overhead of 10-15ms for normal requests, which is significant enough
that it isn't the default, but shouldn't be a problem to run in
production if you do need it.