### PR TITLE
Enable installation on Windows

### DIFF
--- a/ext/allocations/allocations.c
+++ b/ext/allocations/allocations.c
@@ -8,7 +8,7 @@ VALUE mScoutApm;
 VALUE mInstruments;
 VALUE cAllocations;
 
-#ifdef RUBY_INTERNAL_EVENT_NEWOBJ
+#if defined(RUBY_INTERNAL_EVENT_NEWOBJ) && !defined(_WIN32)
 
 #include <sys/resource.h> // is this needed?
 #include <sys/time.h>

--- a/ext/rusage/rusage.c
+++ b/ext/rusage/rusage.c
@@ -1,10 +1,35 @@
 // VERSION = "x.y.z"
 #include <ruby.h>
+#ifdef _WIN32
+#define RUSAGE_SELF 0
+#define RUSAGE_CHILDREN 0
+#else
 #include <sys/resource.h>
+#endif
 
 VALUE v_usage_struct;
 
 static VALUE do_rusage_get(int who){
+#ifdef _WIN32
+  return rb_struct_new(v_usage_struct,
+      rb_float_new(0),
+      rb_float_new(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0),
+      LONG2NUM(0)
+   );
+#else // _WIN32
   struct rusage r;
   int ret;
 
@@ -30,6 +55,7 @@ static VALUE do_rusage_get(int who){
       LONG2NUM(r.ru_nvcsw),
       LONG2NUM(r.ru_nivcsw)
    );
+#endif // _WIN32
 }
 
 static VALUE rusage_get(int argc, VALUE* argv, VALUE mod){

--- a/ext/stacks/stacks.c
+++ b/ext/stacks/stacks.c
@@ -33,7 +33,10 @@
 #ifdef __linux__
 #include <sys/syscall.h>
 #endif
+
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 #include "scout_atomics.h"
 
@@ -77,7 +80,7 @@ const long INTERVAL = 1000; // 1ms
 
 
 
-#ifdef RUBY_INTERNAL_EVENT_NEWOBJ
+#if defined(RUBY_INTERNAL_EVENT_NEWOBJ) && !defined(_WIN32)
 
 // Forward Declarations
 static void init_thread_vars();


### PR DESCRIPTION
The strategy is to `#ifdef` around linux/posix specific code so that installation doesn't fail on Windows for app development purposes. This pr does not attempt to enable correct stats collection on Windows. Related: https://github.com/scoutapp/scout_apm_ruby/issues/91