### PR TITLE
Don't run the background worker task after being shut down

### DIFF
--- a/lib/scout_apm/background_worker.rb
+++ b/lib/scout_apm/background_worker.rb
@@ -36,12 +36,6 @@ module ScoutApm
 
       loop do
         begin
-          # Bail out if @keep_running is false
-          unless @keep_running
-            ScoutApm::Agent.instance.logger.debug "Background Worker: breaking from loop"
-            break
-          end
-
           now = Time.now
 
           # Sleep the correct amount of time to reach next_time
@@ -49,6 +43,12 @@ module ScoutApm
             sleep_time = next_time - now
             sleep(sleep_time) if sleep_time > 0
             now = Time.now
+          end
+
+          # Bail out if @keep_running is false
+          unless @keep_running
+            ScoutApm::Agent.instance.logger.debug "Background Worker: breaking from loop"
+            break
           end
 
           @task.call


### PR DESCRIPTION
The background worker is firing its task one last time, when I don't
think it should.

The order of shutting down:

* Agent class at_exit handler fires
* Agent calls BackgroundWorker.stop (setting @keep_running = false)
* Agent calls store.write_to_layaway(force)
  * Store writes any in-memory data to file
* Agent calls Thread.wakeup on BackgroundWorker & Thread.join on it.
* Background worker was likely waiting on sleep, it wakes from sleep
* It then immediately runs its task.
  * Write to layaway (normal)
  * Attempt to report
* Finally at_exit handler joins the thread, and finishes shutting down

I think that the step where we run the task one last time is
unnecessary, and potentially overwriting files during its layaway write.
And a report could take several seconds if our checkin server is slow,
and risks a hard (timedout) shutdown, and loss of accumulated layaway
data.