### PR TITLE
Simple Rack instrumentation

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -143,6 +143,8 @@ require 'scout_apm/middleware'
 
 require 'scout_apm/instant/middleware'
 
+require 'scout_apm/rack'
+
 if defined?(Rails) && defined?(Rails::VERSION) && defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR >= 3 && defined?(Rails::Railtie)
   module ScoutApm
     class Railtie < Rails::Railtie

--- a/lib/scout_apm/rack.rb
+++ b/lib/scout_apm/rack.rb
@@ -1,0 +1,26 @@
+module ScoutApm
+  module Rack
+    def self.install!
+      ScoutApm::Agent.instance.start(:skip_app_server_check => true)
+      ScoutApm::Agent.instance.start_background_worker
+    end
+
+    def self.transaction(endpoint_name, env)
+      req = ScoutApm::RequestManager.lookup
+      req.annotate_request(:uri => env["REQUEST_PATH"]) rescue nil
+      req.context.add_user(:ip => env["REMOTE_ADDR"]) rescue nil
+
+      req.web!
+      req.start_layer(ScoutApm::Layer.new('Controller', endpoint_name))
+
+      begin
+        yield
+      rescue
+        req.error!
+        raise
+      ensure
+        req.stop_layer
+      end
+    end
+  end
+end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -53,7 +53,7 @@ module ScoutApm
       @error = false
       @instant_key = nil
       @mem_start = mem_usage
-      @dev_trace =  ScoutApm::Agent.instance.config.value('dev_trace') && Rails.env.development?
+      @dev_trace =  ScoutApm::Agent.instance.config.value('dev_trace') && ScoutApm::Agent.instance.environment.env == "development"
     end
 
     def start_layer(layer)


### PR DESCRIPTION
Usage in a minimal rack app:

    require 'rubygems'
    require 'bundler'
    Bundler.require

    ScoutApm::Rack.install!

    app = Proc.new do |env|
      ScoutApm::Rack.transaction("Basic", env) do
        sleep 2
        ['200', {'Content-Type' => 'text/html'}, ['A barebones rack app.']]
      end
    end

    run app