### PR TITLE
Add automatic instrumentation of API & Metal controllers

### DIFF
--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -297,6 +297,7 @@ module ScoutApm
         end
       end
 
+      install_instrument(ScoutApm::Instruments::ActionView)
       install_instrument(ScoutApm::Instruments::ActiveRecord)
       install_instrument(ScoutApm::Instruments::Moped)
       install_instrument(ScoutApm::Instruments::Mongoid)

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -20,57 +20,40 @@ module ScoutApm
         # before and after filter timing. Instrumenting Base includes those
         # filters, at the expense of missing out on controllers that don't use
         # the full Rails stack.
-        if defined?(::ActionController) && defined?(::ActionController::Base)
-          ScoutApm::Agent.instance.logger.info "Instrumenting ActionController::Base"
-          ::ActionController::Base.class_eval do
-            # include ScoutApm::Tracer
-            include ScoutApm::Instruments::ActionControllerRails3Rails4Instruments
-          end
-        end
-
-        if defined?(::ActionView) && defined?(::ActionView::PartialRenderer)
-          ScoutApm::Agent.instance.logger.info "Instrumenting ActionView::PartialRenderer"
-          ::ActionView::PartialRenderer.class_eval do
-            include ScoutApm::Tracer
-
-            instrument_method :render_partial,
-              :type => "View",
-              :name => '#{@template.virtual_path rescue "Unknown Partial"}/Rendering',
-              :scope => true
-
-            instrument_method :collection_with_template,
-              :type => "View",
-              :name => '#{@template.virtual_path rescue "Unknown Collection"}/Rendering',
-              :scope => true
+        if defined?(::ActionController)
+          if defined?(::ActionController::Base)
+            ScoutApm::Agent.instance.logger.info "Instrumenting ActionController::Base"
+            ::ActionController::Base.class_eval do
+              # include ScoutApm::Tracer
+              include ScoutApm::Instruments::ActionControllerRails3Rails4Instruments
+            end
           end
 
-          ScoutApm::Agent.instance.logger.info "Instrumenting ActionView::TemplateRenderer"
-          ::ActionView::TemplateRenderer.class_eval do
-            include ScoutApm::Tracer
-            instrument_method :render_template,
-              :type => "View",
-              :name => '#{args[0].virtual_path rescue "Unknown"}/Rendering',
-              :scope => true
+          if defined?(::ActionController::Metal)
+            ScoutApm::Agent.instance.logger.info "Instrumenting ActionController::Metal"
+            ::ActionController::Metal.class_eval do
+              include ScoutApm::Instruments::ActionControllerMetalInstruments
+            end
+          end
+
+          if defined?(::ActionController::API)
+            ScoutApm::Agent.instance.logger.info "Instrumenting ActionController::Api"
+            ::ActionController::API.class_eval do
+              include ScoutApm::Instruments::ActionControllerRails3Rails4Instruments
+            end
           end
         end
       end
     end
 
-    module ActionControllerRails3Rails4Instruments
-      def process_action(*args)
+    module ActionControllerMetalInstruments
+      def process(*args)
         req = ScoutApm::RequestManager.lookup
         req.annotate_request(:uri => scout_transaction_uri(request))
 
         # IP Spoofing Protection can throw an exception, just move on w/o remote ip
         req.context.add_user(:ip => request.remote_ip) rescue nil
-
         req.set_headers(request.headers)
-
-        # Check if this this request is to be reported instantly
-        if instant_key = request.cookies['scoutapminstant']
-          Agent.instance.logger.info "Instant trace request with key=#{instant_key} for path=#{path}"
-          req.instant_key = instant_key
-        end
 
         req.web!
 
@@ -83,7 +66,7 @@ module ScoutApm
         ensure
           req.stop_layer
         end
-      end # process_action
+      end
 
       # Given an +ActionDispatch::Request+, formats the uri based on config settings.
       def scout_transaction_uri(request)
@@ -94,8 +77,21 @@ module ScoutApm
           request.filtered_path
         end
       end
+    end
 
-    end # ActionControllerRails3Rails4Instruments
+    module ActionControllerRails3Rails4Instruments
+      def process_action(*args)
+        req = ScoutApm::RequestManager.lookup
+
+        # Check if this this request is to be reported instantly
+        if instant_key = request.cookies['scoutapminstant']
+          Agent.instance.logger.info "Instant trace request with key=#{instant_key} for path=#{path}"
+          req.instant_key = instant_key
+        end
+
+        super
+      end
+    end
   end
 end
 

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -65,7 +65,6 @@ module ScoutApm
 
             if current_layer.type == "Controller"
               # Don't start a new layer if ActionController::API or ActionController::Base handled it already.
-              STDOUT.puts "Skipping because already started controller layer"
               super
             else
               req.annotate_request(:uri => ScoutApm::Instruments::ActionControllerRails3Rails4.scout_transaction_uri(request))
@@ -77,9 +76,7 @@ module ScoutApm
               req.web!
 
               resolved_name = scout_action_name(*args)
-              STDOUT.puts("Got action name: #{resolved_name}")
               req.start_layer( ScoutApm::Layer.new("Controller", "#{controller_path}/#{resolved_name}") )
-              STDOUT.puts "Starting controller layer"
               begin
                 super
               rescue
@@ -87,7 +84,6 @@ module ScoutApm
                 raise
               ensure
                 req.stop_layer
-                STDOUT.puts "Stopping controller layer"
               end
             end
           end

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -43,6 +43,55 @@ module ScoutApm
             end
           end
         end
+
+        # Returns a new anonymous module each time it is called. So
+        # we can insert this multiple times into the ancestors
+        # stack. Otherwise it only exists the first time you include it
+        # (under Metal, instead of under API) and we miss instrumenting
+        # before_action callbacks
+      end
+
+      def self.build_instrument_module
+        Module.new do
+          def process_action(*args)
+            req = ScoutApm::RequestManager.lookup
+            current_layer = req.current_layer
+
+            # Check if this this request is to be reported instantly
+            if instant_key = request.cookies['scoutapminstant']
+              Agent.instance.logger.info "Instant trace request with key=#{instant_key} for path=#{path}"
+              req.instant_key = instant_key
+            end
+
+            if current_layer.type == "Controller"
+              # Don't start a new layer if ActionController::API or ActionController::Base handled it already.
+              STDOUT.puts "Skipping because already started controller layer"
+              super
+            else
+              req.annotate_request(:uri => ScoutApm::Instruments::ActionControllerRails3Rails4.scout_transaction_uri(request))
+
+              # IP Spoofing Protection can throw an exception, just move on w/o remote ip
+              req.context.add_user(:ip => request.remote_ip) rescue nil
+              req.set_headers(request.headers)
+
+              req.web!
+
+              resolved_name = scout_action_name(*args)
+              STDOUT.puts("Got action name: #{resolved_name}")
+              req.start_layer( ScoutApm::Layer.new("Controller", "#{controller_path}/#{resolved_name}") )
+              STDOUT.puts "Starting controller layer"
+              begin
+                super
+              rescue
+                req.error!
+                raise
+              ensure
+                req.stop_layer
+                STDOUT.puts "Stopping controller layer"
+              end
+            end
+          end
+        end
       end
 
       # Given an +ActionDispatch::Request+, formats the uri based on config settings.
@@ -57,73 +106,18 @@ module ScoutApm
     end
 
     module ActionControllerMetalInstruments
-      def process_action(*args)
-        req = ScoutApm::RequestManager.lookup
-        current_layer = req.current_layer
+      include ScoutApm::Instruments::ActionControllerRails3Rails4.build_instrument_module
 
-        # Check if this this request is to be reported instantly
-        if instant_key = request.cookies['scoutapminstant']
-          Agent.instance.logger.info "Instant trace request with key=#{instant_key} for path=#{path}"
-          req.instant_key = instant_key
-        end
-
-        if current_layer.type == "Controller"
-          # Don't start a new layer if ActionController::API or ActionController::Base handled it already.
-          STDOUT.puts "Skipping in metal"
-          super
-        else
-          req.annotate_request(:uri => ScoutApm::Instruments::ActionControllerRails3Rails4.scout_transaction_uri(request))
-
-          # IP Spoofing Protection can throw an exception, just move on w/o remote ip
-          req.context.add_user(:ip => request.remote_ip) rescue nil
-          req.set_headers(request.headers)
-
-          req.web!
-
-          action_name = args[0]
-          req.start_layer( ScoutApm::Layer.new("Controller", "#{controller_path}/#{action_name}") )
-          STDOUT.puts "Metal Instruments: Starting Layer"
-          begin
-            super
-          rescue
-            req.error!
-            raise
-          ensure
-          STDOUT.puts "Metal Instruments: Stopping Layer"
-            req.stop_layer
-          end
-        end
+      def scout_action_name(*args)
+        action_name = args[0]
       end
-
     end
 
     module ActionControllerRails3Rails4Instruments
-      def process_action(*args)
-        req = ScoutApm::RequestManager.lookup
-        current_layer = req.current_layer
+      include ScoutApm::Instruments::ActionControllerRails3Rails4.build_instrument_module
 
-        if current_layer.type == "Controller"
-          # Don't start a new layer if metal got it.
-          STDOUT.puts "Skipping in ControllerInstruments"
-          super
-        else
-          req.annotate_request(:uri => ScoutApm::Instruments::ActionControllerRails3Rails4.scout_transaction_uri(request))
-          req.context.add_user(:ip => request.remote_ip) rescue nil
-          req.set_headers(request.headers)
-          req.web!
-
-          req.start_layer( ScoutApm::Layer.new("Controller", "#{controller_path}/#{action_name}") )
-          STDOUT.puts "ControllerInstruments: Starting Layer"
-          begin
-            super
-          rescue
-            req.error!
-            raise
-          ensure
-            STDOUT.puts "ControllerInstruments: Stopping Layer"
-            req.stop_layer
-          end
-        end
+      def scout_action_name(*args)
+        action_name
       end
     end
   end

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -25,7 +25,7 @@ module ScoutApm
             ScoutApm::Agent.instance.logger.info "Instrumenting ActionController::Base"
             ::ActionController::Base.class_eval do
               # include ScoutApm::Tracer
-              include ScoutApm::Instruments::ActionControllerRails3Rails4Instruments
+              include ScoutApm::Instruments::ActionControllerBaseInstruments
             end
           end
 
@@ -39,7 +39,7 @@ module ScoutApm
           if defined?(::ActionController::API)
             ScoutApm::Agent.instance.logger.info "Instrumenting ActionController::Api"
             ::ActionController::API.class_eval do
-              include ScoutApm::Instruments::ActionControllerRails3Rails4Instruments
+              include ScoutApm::Instruments::ActionControllerAPIInstruments
             end
           end
         end
@@ -109,7 +109,19 @@ module ScoutApm
       end
     end
 
+    # Empty, noop module to provide compatibility w/ previous manual instrumentation
     module ActionControllerRails3Rails4Instruments
+    end
+
+    module ActionControllerBaseInstruments
+      include ScoutApm::Instruments::ActionControllerRails3Rails4.build_instrument_module
+
+      def scout_action_name(*args)
+        action_name
+      end
+    end
+
+    module ActionControllerAPIInstruments
       include ScoutApm::Instruments::ActionControllerRails3Rails4.build_instrument_module
 
       def scout_action_name(*args)

--- a/lib/scout_apm/instruments/action_view.rb
+++ b/lib/scout_apm/instruments/action_view.rb
@@ -1,0 +1,49 @@
+module ScoutApm
+  module Instruments
+    # instrumentation for Rails 3 and Rails 4 is the same.
+    class ActionView
+      attr_reader :logger
+
+      def initalize(logger=ScoutApm::Agent.instance.logger)
+        @logger = logger
+        @installed = false
+      end
+
+      def installed?
+        @installed
+      end
+
+      def install
+        @installed = true
+
+        if defined?(::ActionView) && defined?(::ActionView::PartialRenderer)
+          ScoutApm::Agent.instance.logger.info "Instrumenting ActionView::PartialRenderer"
+          ::ActionView::PartialRenderer.class_eval do
+            include ScoutApm::Tracer
+
+            instrument_method :render_partial,
+              :type => "View",
+              :name => '#{@template.virtual_path rescue "Unknown Partial"}/Rendering',
+              :scope => true
+
+            instrument_method :collection_with_template,
+              :type => "View",
+              :name => '#{@template.virtual_path rescue "Unknown Collection"}/Rendering',
+              :scope => true
+          end
+
+          ScoutApm::Agent.instance.logger.info "Instrumenting ActionView::TemplateRenderer"
+          ::ActionView::TemplateRenderer.class_eval do
+            include ScoutApm::Tracer
+            instrument_method :render_template,
+              :type => "View",
+              :name => '#{args[0].virtual_path rescue "Unknown"}/Rendering',
+              :scope => true
+          end
+        end
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
The big gotcha I had to work around here is that API & Base controllers both inherit from Metal. So if I instrument both, the code needs to be sure not to start two Controller layers.  See the specific commit messages for the mechanism I used for that (the dynamic module stuff)