### PR TITLE
Don't install instruments when monitor:false

### DIFF
--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -273,11 +273,19 @@ module ScoutApm
         each {|old_timestamp| request_histograms_by_time.delete(old_timestamp) }
     end
 
-    # If we want to skip the app_server_check, then we must load it.
+    # 1. Dev trace needs to install instruments, even if background
+    #    worker & reporting infrastructure shouldn't start.
+    # 2. If monitor is false, then never allow the agent to start, even
+    #    if the middleware attempts to.
+    # 3. Then allow overriding (skip_app_server_check) if the
+    #    app_server_integration or bg worker checks don't catch things right
+    #    (this often happens in passenger)
+    # 4. Then we only install instruments if we know what's up with app
+    #    server or bg job
     def should_load_instruments?(options={})
-      return true if options[:skip_app_server_check]
       return true if config.value('dev_trace')
       return false if !apm_enabled?
+      return true if options[:skip_app_server_check]
       environment.app_server_integration.found? || !background_job_missing?
     end
 


### PR DESCRIPTION
If the configuration monitor: false is set, we'll never actually record
anything that the instruments pick up.

We still need to install them in the case of dev trace, since dev trace
needs the instruments to do its work (even though dev trace won't start
the background worker, and uses a fake Store)