### PR TITLE
Abstract recording approach from TrackedRequest

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -117,6 +117,8 @@ require 'scout_apm/fake_store'
 require 'scout_apm/tracer'
 require 'scout_apm/context'
 require 'scout_apm/instant_reporting'
+require 'scout_apm/background_recorder'
+require 'scout_apm/synchronous_recorder'
 
 require 'scout_apm/metric_meta'
 require 'scout_apm/metric_stats'

--- a/lib/scout_apm/background_recorder.rb
+++ b/lib/scout_apm/background_recorder.rb
@@ -1,0 +1,42 @@
+# Provide a background thread queue to do the processing of
+# TrackedRequest objects, to remove it from the hot-path of returning a
+# web response
+
+module ScoutApm
+  class BackgroundRecorder
+    attr_reader :queue
+    attr_reader :thread
+    attr_reader :logger
+
+    def initialize(logger)
+      @logger = logger
+      @queue = Queue.new
+    end
+
+    def start
+      logger.info("Starting BackgroundRecorder")
+      @thread = Thread.new(&method(:thread_func))
+      self
+    end
+
+    def stop
+      @thread.kill
+    end
+
+    def record!(request)
+      start unless @thread.alive?
+      @queue.push(request)
+    end
+
+    def thread_func
+      while req = queue.pop
+        begin
+          # For now, just proxy right back into the TrackedRequest object's record function
+          req.record!
+        rescue => e
+          logger.warn("Error in BackgroundRecorder - #{e.message} : #{e.backtrace}")
+        end
+      end
+    end
+  end
+end

--- a/lib/scout_apm/background_recorder.rb
+++ b/lib/scout_apm/background_recorder.rb
@@ -31,6 +31,7 @@ module ScoutApm
     def thread_func
       while req = queue.pop
         begin
+          logger.debug("recording in thread. Queue size: #{queue.size}")
           # For now, just proxy right back into the TrackedRequest object's record function
           req.record!
         rescue => e

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -34,6 +34,7 @@ module ScoutApm
   class Config
     KNOWN_CONFIG_OPTIONS = [
         'application_root',
+        'async_recording',
         'compress_payload',
         'config_file',
         'data_file',
@@ -127,11 +128,12 @@ module ScoutApm
 
 
     SETTING_COERCIONS = {
-      "monitor"                => BooleanCoercion.new,
-      "enable_background_jobs" => BooleanCoercion.new,
-      "dev_trace"              => BooleanCoercion.new,
+      "async_recording"        => BooleanCoercion.new,
       "detailed_middleware"    => BooleanCoercion.new,
+      "dev_trace"              => BooleanCoercion.new,
+      "enable_background_jobs" => BooleanCoercion.new,
       "ignore"                 => JsonCoercion.new,
+      "monitor"                => BooleanCoercion.new,
     }
 
 

--- a/lib/scout_apm/synchronous_recorder.rb
+++ b/lib/scout_apm/synchronous_recorder.rb
@@ -1,0 +1,26 @@
+# Provide a synchronous approach to recording TrackedRequests
+# Doesn't attempt to background the work, or do it elsewhere. It happens
+# inline, in the caller thread right when record! is called
+
+module ScoutApm
+  class SynchronousRecorder
+    attr_reader :logger
+
+    def initialize(logger)
+      @logger = logger
+    end
+
+    def start
+      # nothing to do
+      self
+    end
+
+    def stop
+      # nothing to do
+    end
+
+    def record!(request)
+      request.record!
+    end
+  end
+end


### PR DESCRIPTION
This allows different approaches on how to handle the TrackedRequest
object after the request is finished.

This PR adds a configuration option to allow tracing of tracked requests
in a different thread than the request itself, allowing it to get out of
the critical path of the response.

With async_recording setting:

```
Before:

Start Req --> End Req --> #record! (& process) --> Store --> Response sent

After:

Start Req --> End Req --> Response sent
                      --> #record! (& process) --> Store
```

The goal is that the time spent recording the details of the request is
now not in the way of returning the request.  The same amount of work is
done, just in a background thread instead of the hot-path of the
request.