### PR TITLE
Don't start the agent in Rails console

### DIFF
--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -89,6 +89,11 @@ module ScoutApm
         return false unless force?
       end
 
+      if environment.interactive?
+        logger.warn "Agent attempting to load in interactive mode. #{force? ? 'Forcing agent to start' : 'Not starting agent'}"
+        return false unless force?
+      end
+
       if app_server_missing?(options) && background_job_missing?
         if force?
           logger.warn "Agent starting (forced)"

--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -153,6 +153,11 @@ module ScoutApm
       background_job_integration && background_job_integration.name
     end
 
+    # If both stdin & stdout are interactive and the Rails::Console constant is defined
+    def interactive?
+      defined?(::Rails::Console) && $stdout.isatty && $stdin.isatty
+    end
+
     ### ruby checks
 
     def rubinius?


### PR DESCRIPTION
Background: We already mostly did this, but in a roundabout way by checking if we were loading into a web server (or a background job env). This is more direct and avoids some edge cases we've seen.
