### PR TITLE
Also find queue of a resque job from klass.queue

### DIFF
--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -3,11 +3,10 @@ module ScoutApm
     module Resque
       def around_perform_with_scout_instruments(*args)
         job_name = self.to_s
-        queue = @queue
+        queue = find_queue
 
         req = ScoutApm::RequestManager.lookup
         req.job!
-        # req.annotate_request(:queue_latency => latency(msg))
 
         begin
           req.start_layer(ScoutApm::Layer.new('Queue', queue))
@@ -23,6 +22,12 @@ module ScoutApm
           req.stop_layer if started_job
           req.stop_layer if started_queue
         end
+      end
+
+      def find_queue
+        return @queue if @queue
+        return queue if self.respond_to?(:queue)
+        return "unknown"
       end
     end
   end


### PR DESCRIPTION
Also add a fallback. We shouldn't ever allow queue to be nil, even
though I don't think resque will run a job if both @queue and #queue are
missing. Always have a fallback of "unknown", so we can report smething.

This oversight of queue name was manifesting as a call to nil.downcase
when we go to process the JobRecord.