### PR TITLE
Fix Rails 5+ SQL parameter logging

### DIFF
--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -122,7 +122,7 @@ module ScoutApm
             current_layer.desc = desc
           end
 
-          log_without_scout_instruments(sql, name, &block)
+          log_without_scout_instruments(*args, &block)
 
         # OR: Start a new layer, we didn't pick up instrumentation earlier in the stack.
         else
@@ -130,7 +130,7 @@ module ScoutApm
           layer.desc = desc
           req.start_layer(layer)
           begin
-            log_without_scout_instruments(sql, name, &block)
+            log_without_scout_instruments(*args, &block)
           ensure
             req.stop_layer
           end


### PR DESCRIPTION
We were seeing no SQL parameters logging to our normal Rails logs and this was why!

I'd like to encourage Scout to please use ActiveRecord's instrumentation instead of overriding methods. This could just be a subscription to `sql.active_record` now instead of messing with alias method chains.

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L542-L543