### PR TITLE
Be more generous with max sql length we're willing to scrub

### DIFF
--- a/lib/scout_apm/utils/sql_sanitizer.rb
+++ b/lib/scout_apm/utils/sql_sanitizer.rb
@@ -74,8 +74,10 @@ module ScoutApm
         encodings.all?{|enc| Encoding.find(enc) rescue false}
       end
 
+      MAX_SQL_LENGTH = 16384
+
       def scrubbed(str)
-        return '' if !str.is_a?(String) || str.length > 4000 # safeguard - don't sanitize or scrub large SQL statements
+        return '' if !str.is_a?(String) || str.length > MAX_SQL_LENGTH # safeguard - don't sanitize or scrub large SQL statements
         return str if !str.respond_to?(:encode) # Ruby <= 1.8 doesn't have string encoding
         return str if str.valid_encoding? # Whatever encoding it is, it is valid and we can operate on it
         ScoutApm::Agent.instance.context.logger.debug "Scrubbing invalid sql encoding."


### PR DESCRIPTION
SQL Scrubbing is only used when we capture traces, which only happens a
handful of times per minute, so performance isn't as big a deal now as
when we initially introduced this limit. Back then, we were running sql
scrubbing eagerly on nearly every SQL statement