### PR TITLE
Ignore children of Net::HTTP instrument layers

### DIFF
--- a/lib/scout_apm/instruments/net_http.rb
+++ b/lib/scout_apm/instruments/net_http.rb
@@ -26,7 +26,7 @@ module ScoutApm
             include ScoutApm::Tracer
 
             def request_with_scout_instruments(*args,&block)
-              self.class.instrument("HTTP", "request", :desc => request_scout_description(args.first)) do
+              self.class.instrument("HTTP", "request", :ignore_children => true, :desc => request_scout_description(args.first)) do
                 request_without_scout_instruments(*args, &block)
               end
             end


### PR DESCRIPTION
When using Faraday using the default adapter (`Net::HTTP`), if `rest-client` is also installed it can cause double-counting of the number of HTTP requests. This commit ignores any children of `Net::HTTP.request` calls.