### PR TITLE
Move creation of reporting periods, and samplers to own method

### DIFF
--- a/lib/scout_apm/reporting.rb
+++ b/lib/scout_apm/reporting.rb
@@ -24,6 +24,9 @@ module ScoutApm
     #
     # At any given point, there is data in each of those steps, moving its way through the process
     def process_metrics
+      # Do any per-minute work necessary for the store
+      context.store.tick!
+
       # Write the previous minute's data to the shared-across-process layaway file.
       context.store.write_to_layaway(context.layaway)
 

--- a/lib/scout_apm/store.rb
+++ b/lib/scout_apm/store.rb
@@ -88,8 +88,13 @@ module ScoutApm
       logger.debug("Writing to layaway#{" (Forced)" if force}")
 
       @reporting_periods.select { |time, rp| force || (time.timestamp < current_timestamp.timestamp) }.
-                         each   { |time, rp| collect_samplers(rp) }.
                          each   { |time, rp| write_reporting_period(layaway, time, rp) }
+    end
+
+    # For each tick (minute), be sure we have a reporting period, and that samplers are run for it.
+    def tick!
+      rp = current_period
+      collect_samplers(rp)
     end
 
     def write_reporting_period(layaway, time, rp)


### PR DESCRIPTION
Previously, if a worker got no traffic at all, we would not necessarily
create a ReportingPeriod object for that minute, which in turn would
mean we didn't collect samplers.

The result was memory usage appearing to jump up & down more than it
really was (since we were missing certain processes' readings).

Now, the store has a #tick! method to do any per-minute work, including
creating that reporting period, and reading samplers into it.

ALSO: this fixes another minor issue related to shutdown. When shutting
down, the agent called #write_to_layaway(force). This caused
double-readings of memory when called in the sequence inside of a minute:
  * write_to_layaway normally
  * shutdown
  * write to layaway forced