### PR TITLE
Ensure instruments are installed correctly

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -196,5 +196,5 @@ if defined?(Rails) && defined?(Rails::VERSION) && defined?(Rails::VERSION::MAJOR
     end
   end
 else
-  ScoutApm::Agent.instance.start
+  ScoutApm::Agent.instance.install
 end

--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -35,15 +35,14 @@ module ScoutApm
     def install(force=false)
       context.config = ScoutApm::Config.with_file(context, context.config.value("config_file"))
 
-      context.logger.info "Scout Agent [#{ScoutApm::VERSION}] Initialized"
+      logger.info "Scout Agent [#{ScoutApm::VERSION}] Initialized"
 
-      @instrument_manager = ScoutApm::InstrumentManager.new(context)
-      @instrument_manager.install! if should_load_instruments? || force
+      instrument_manager.install! if should_load_instruments? || force
 
       install_background_job_integrations
       install_app_server_integration
 
-      logger.info "Scout Agent [#{ScoutApm::VERSION}] installed"
+      logger.info "Scout Agent [#{ScoutApm::VERSION}] Installed"
 
       context.installed!
 
@@ -69,6 +68,8 @@ module ScoutApm
 
       install unless context.installed?
 
+      instrument_manager.install! # noop if it was installed earlier
+
       context.started!
 
       log_environment
@@ -77,6 +78,10 @@ module ScoutApm
       @app_server_load ||= AppServerLoad.new(context).run
 
       start_background_worker
+    end
+
+    def instrument_manager
+      @instrument_manager ||= ScoutApm::InstrumentManager.new(context)
     end
 
     def log_environment
@@ -123,10 +128,13 @@ module ScoutApm
       return !context.environment.forking?
     end
 
+    # monitor is the key configuration here. If it is true, then we want the
+    # instruments. If it is false, we mostly don't want them, unless you're
+    # asking for devtrace (ie. not reporting to apm servers as a real app, but
+    # only for local browsers).
     def should_load_instruments?
       return true if context.config.value('dev_trace')
-      return false unless context.config.value('monitor')
-      context.environment.app_server_integration.found? || context.environment.background_job_integrations.any?
+      context.config.value('monitor')
     end
 
     #################################

--- a/lib/scout_apm/fake_store.rb
+++ b/lib/scout_apm/fake_store.rb
@@ -37,5 +37,8 @@ module ScoutApm
 
     def add_sampler(sampler)
     end
+
+    def tick!
+    end
   end
 end

--- a/lib/scout_apm/layaway.rb
+++ b/lib/scout_apm/layaway.rb
@@ -55,10 +55,10 @@ module ScoutApm
         @wrote_layaway_limit_error_message ||= logger.error("Layaway: Hit layaway file limit. Not writing to layaway file")
         return false
       end
+      logger.debug("Layaway: wrote time period: #{reporting_period.timestamp}")
       filename = file_for(reporting_period.timestamp)
       layaway_file = LayawayFile.new(context, filename)
       layaway_file.write(reporting_period)
-      logger.debug("Layaway: wrote time period: #{reporting_period.timestamp}")
     rescue => e
       logger.debug("Layaway: error writing: #{e.message}, #{e.backtrace.inspect}")
       raise e

--- a/lib/scout_apm/layaway.rb
+++ b/lib/scout_apm/layaway.rb
@@ -52,7 +52,7 @@ module ScoutApm
     def write_reporting_period(reporting_period, files_limit = MAX_FILES_LIMIT)
       if at_layaway_file_limit?(files_limit)
         # This will happen constantly once we hit this case, so only log the first time
-        @wrote_layaway_limit_error_message ||= logger.error("Hit layaway file limit. Not writing to layaway file")
+        @wrote_layaway_limit_error_message ||= logger.error("Layaway: Hit layaway file limit. Not writing to layaway file")
         return false
       end
       filename = file_for(reporting_period.timestamp)
@@ -102,19 +102,19 @@ module ScoutApm
             if rps.any?
               yield rps
 
-              logger.debug("Deleting the now-reported layaway files for #{timestamp.to_s}")
+              logger.debug("Layaway: Deleting the now-reported files for #{timestamp.to_s}")
               delete_files_for(timestamp) # also removes the coodinator_file
             else
               File.unlink(coordinator_file)
-              logger.debug("No layaway files to report")
+              logger.debug("Layaway: No files to report")
             end
 
-            logger.debug("Checking for any Stale layaway files")
+            logger.debug("Layaway: Checking for any stale files")
             delete_stale_files(timestamp.to_time - STALE_AGE)
 
             true
           rescue Exception => e
-            logger.debug("Caught an exception in with_claim, with the coordination file locked: #{e.message}, #{e.backtrace.inspect}")
+            logger.debug("Layaway: Caught an exception in with_claim, with the coordination file locked: #{e.message}, #{e.backtrace.inspect}")
             raise
           ensure
             # Unlock the file when done!
@@ -130,7 +130,7 @@ module ScoutApm
 
     def delete_files_for(timestamp)
       all_files_for(timestamp).each { |layaway|
-        logger.debug("Deleting layaway file: #{layaway}")
+        logger.debug("Layaway: Deleting file: #{layaway}")
         File.unlink(layaway)
       }
     end
@@ -141,10 +141,10 @@ module ScoutApm
         compact.
         uniq.
         select { |timestamp| timestamp.to_i < older_than.strftime(TIME_FORMAT).to_i }.
-          tap  { |timestamps| logger.debug("Deleting stale layaway files with timestamps: #{timestamps.inspect}") }.
+          tap  { |timestamps| logger.debug("Layaway: Deleting stale files with timestamps: #{timestamps.inspect}") }.
         map    { |timestamp| delete_files_for(timestamp) }
     rescue => e
-      logger.debug("Problem deleting stale files: #{e.message}, #{e.backtrace.inspect}")
+      logger.debug("Layaway: Problem deleting stale files: #{e.message}, #{e.backtrace.inspect}")
     end
 
     private
@@ -210,8 +210,7 @@ module ScoutApm
         map{ |timestamp, list| [timestamp, list.length] }
       ]
 
-
-      logger.debug("Total in #{directory}: #{files_in_temp}. Total Layaway Files: #{all_filenames.size}.  By Timestamp: #{count_per_timestamp.inspect}")
+      logger.debug("Layaway: Total Files in #{directory}: #{files_in_temp}. Total Layaway Files: #{all_filenames.size}.  By Timestamp: #{count_per_timestamp.inspect}")
     end
   end
 end

--- a/lib/scout_apm/layaway.rb
+++ b/lib/scout_apm/layaway.rb
@@ -58,6 +58,10 @@ module ScoutApm
       filename = file_for(reporting_period.timestamp)
       layaway_file = LayawayFile.new(context, filename)
       layaway_file.write(reporting_period)
+      logger.debug("Layaway: wrote time period: #{reporting_period.timestamp}")
+    rescue => e
+      logger.debug("Layaway: error writing: #{e.message}, #{e.backtrace.inspect}")
+      raise e
     end
 
     # Claims a given timestamp by getting an exclusive lock on a timestamped

--- a/lib/scout_apm/layaway_file.rb
+++ b/lib/scout_apm/layaway_file.rb
@@ -18,7 +18,7 @@ module ScoutApm
       deserialize(data)
     rescue NameError, ArgumentError, TypeError => e
       # Marshal error
-      logger.info("Unable to load data from Layaway file, resetting.")
+      logger.info("LayawayFile: Unable to load data")
       logger.debug("#{e.message}, #{e.backtrace.join("\n\t")}")
       nil
     end

--- a/lib/scout_apm/layaway_file.rb
+++ b/lib/scout_apm/layaway_file.rb
@@ -6,6 +6,7 @@ module ScoutApm
 
     def initialize(context, path)
       @path = path
+      @context = context
     end
 
     def logger

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -299,10 +299,6 @@ module ScoutApm
     def ensure_background_worker
       agent = ScoutApm::Agent.instance
       agent.start
-
-      if agent.start_background_worker(:quiet)
-        agent.logger.info("Force Started BG Worker")
-      end
     rescue => e
       true
     end


### PR DESCRIPTION
There was logic to avoid installing instruments when an app server wasn't
detected, and also separate logic to start the agent when a web request
came through. The interaction was that it would start the agent, but not
actually install instruments. So an app would report memory & cpu usage,
but not any throughput or traces.

This ensures that instruments are installed more often (when monitor=true
at least)