### PR TITLE
Be sure to wipe & restore agent_context when using Remote agent

### DIFF
--- a/lib/scout_apm/agent_context.rb
+++ b/lib/scout_apm/agent_context.rb
@@ -41,7 +41,7 @@ module ScoutApm
       @remote_server = ScoutApm::Remote::Server.new(
         bind,
         port,
-        ScoutApm::Remote::Router.new(ScoutApm::SynchronousRecorder.new(logger), logger),
+        ScoutApm::Remote::Router.new(ScoutApm::SynchronousRecorder.new(self), logger),
         logger
       )
 

--- a/lib/scout_apm/logger.rb
+++ b/lib/scout_apm/logger.rb
@@ -8,11 +8,12 @@
 # :stdout => true                          - explicitly force the log to write to stdout (if set, ignore log_file_path)
 # :stderr => true                          - explicitly force the log to write to stderr (if set, ignore log_file_path)
 # :logger_class => Class or String         - a class to use as the underlying logger. Defaults to Ruby's Logger. See notes
-# :log_level => symbol, string, or integer - defualts to INFO level
+# :log_level => symbol, string, or integer - defaults to INFO level
 #
 # The :logger_class option
 #   - allows any class to be used as the underlying logger. Currently requires to respond to:
 #     - debug, info, warn, error, fatal in both string and block form.
+#     - debug?, info?, warn?, error?, fatal?
 #     - #level= with a number (0 = debug, 1 = info, 2= warn, 3=error, 4=fatal)
 #     - #formatter= that takes a Ruby Logger::Formatter class. This method must be here, but the value may be ignored
 #
@@ -38,6 +39,12 @@ module ScoutApm
     def warn(*args, &block); @logger.warn(*args, &block); end
     def error(*args, &block); @logger.error(*args, &block); end
     def fatal(*args, &block); @logger.fatal(*args, &block); end
+
+    def debug?; @logger.debug?; end
+    def info?; @logger.info?; end
+    def warn?; @logger.warn?; end
+    def error?; @logger.error?; end
+    def fatal?; @logger.fatal?; end
 
     def log_level=(level)
       @logger.level = log_level_from_opts(level)

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -251,7 +251,7 @@ module ScoutApm
 
       # If we didn't have store, but we're trying to record anyway, go
       # figure that out. (this happens in Remote Agent scenarios)
-      restore_store if @store.nil?
+      restore_from_dump! if @agent_context.nil?
 
       # Bail out early if the user asked us to ignore this uri
       return if @agent_context.ignored_uris.ignore?(annotations[:uri])
@@ -430,11 +430,14 @@ module ScoutApm
       @call_set = nil
       @store = nil
       @recorder = nil
+      @agent_context = nil
     end
 
     # Go re-fetch the store based on what the Agent's official one is. Used
     # after hydrating a dumped TrackedRequest
-    def restore_store
+    def restore_from_dump!
+      @agent_context = ScoutApm::Agent.instance.context
+      @recorder = @agent_context.recorder
       @store = @agent_context.store
     end
   end


### PR DESCRIPTION
If we don't, we may rehydrate a modified agent context from the child
process, which will include a FakeStore, and will then figure out
metrics, and then drop them.