### PR TITLE
Ensures log directory exists

### DIFF
--- a/test/unit/logger_test.rb
+++ b/test/unit/logger_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
+require 'fileutils'
 
 require 'scout_apm/logger'
 
 class LoggerTest < Minitest::Test
   def setup
     @env_root = Pathname.new(File.dirname(__FILE__)) + "../../"
+    FileUtils.mkdir_p(@env_root + "log")
   end
 
   def test_detect_stdout


### PR DESCRIPTION
If the `log/` directory does not exist, `ScoutApm::Logger` falls back to `STDOUT`. Therefore, a fresh checkout of `scout_app_ruby` fails with something like:

```
  1) Failure:                                                                              
LoggerTest#test_pick_log_file_with_no_options [/home/alindeman/src/github.com/scoutapp/scout_apm_ruby/test/unit/logger_test.rb:29]:                      
--- expected                                                                
+++ actual                                                                                                                                               
@@ -1 +1 @@                                                                                             
-"/home/alindeman/src/github.com/scoutapp/scout_apm_ruby/log/scout_apm.log"
+#<IO:<STDOUT>>  
```

It seems like the tests assume `log/` exists, so it seems like making sure it actually does is right. But if anyone sees a better solution, I'm happy to be nudged in that direction.