### PR TITLE
Fix recording backtraces

### DIFF
--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -59,6 +59,7 @@ module ScoutApm
       @instant_key = nil
       @mem_start = mem_usage
       @recorder = agent_context.recorder
+      @real_request = false
 
       ignore_request! if @recorder.nil?
     end
@@ -122,7 +123,7 @@ module ScoutApm
 
     # Have we seen a "controller" or "job" layer so far?
     def real_request?
-      !!@real_request
+      @real_request
     end
 
     # Grab the currently running layer. Useful for adding additional data as we


### PR DESCRIPTION
When #145 was fixed, we changed the definition of the `web?` and `job?`
methods in TrackedRequest to look at the real stack of layers, rather
than using marker booleans set by the ActionController and background
job instrumentations.

Because of that change, and caching of the values, an optimization
check in `capture_backtrace?` was always returning false, skipping
backtrace collection.

The fix is to untangle the logical `web?` call into two distinct items.
One is for recording, and is still called `web?` (and `job?`). It looks
at the layers.

Then adding a new flag, set while a request is running, that marks it as
a `real_request!`. That then is a signal to future instrumentation that
its worthwhile to enable all the various captures we do, and that we're
not wasting time.

The initial reason for this optimization was that Sidekiq is constantly
churning TrackedRequest objects, every time it checks Redis (and other
bookkeeping tasks). We found that recording backtraces was rather
expensive in that case, and they were just being collected, then thrown
away.