### PR TITLE
Pins rake to 10.5 on Ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ if RUBY_VERSION <= "1.8.7"
   gem "activesupport", "~> 3.2"
   gem "i18n", "~> 0.6.11"
   gem "pry", "~> 0.9.12"
+  gem "rake", "~> 10.5"
 end


### PR DESCRIPTION
Not sure why this didn't show up as an issue until now, but this should fix the Travis build failure on Ruby 1.8.7.