### PR TITLE
Change stale layaway regex, add test

### DIFF
--- a/lib/scout_apm/layaway.rb
+++ b/lib/scout_apm/layaway.rb
@@ -188,7 +188,7 @@ module ScoutApm
     end
 
     def timestamp_from_filename(filename)
-      match = filename.match(%r{scout_(.*)_.*\.data})
+      match = filename.match(%r{scout_(\d+)_\d+\.data})
       if match
         match[1]
       else

--- a/lib/scout_apm/layaway.rb
+++ b/lib/scout_apm/layaway.rb
@@ -188,7 +188,7 @@ module ScoutApm
     end
 
     def timestamp_from_filename(filename)
-      match = filename.match(%r{scout_(\d+)_\d+\.data})
+      match = filename.match(%r{scout_(\d+)_\d+\.data\z})
       if match
         match[1]
       else

--- a/test/unit/layaway_test.rb
+++ b/test/unit/layaway_test.rb
@@ -46,4 +46,35 @@ class LayawayTest < Minitest::Test
 
     layaway.delete_files_for(:all)
   end
+
+  def test_layaway_stale_regex_pattern
+    data_dir = '/tmp/scout_apm_test/shared/scout_apm'
+    FileUtils.mkdir_p data_dir
+    # Clean out files
+    FileUtils.safe_unlink(Dir.glob("#{data_dir}/scout_*_*.data"))
+
+    config = make_fake_config({'data_file' => data_dir})
+    env = make_fake_environment(:root => '/tmp/scout_apm_test')
+    context = ScoutApm::AgentContext.new().tap{|c| c.config = config; c.environment = env }
+    layaway = ScoutApm::Layaway.new(context)
+
+    not_stale_time_integer = Time.now.strftime(ScoutApm::Layaway::TIME_FORMAT).to_i
+    stale_time_integer = not_stale_time_integer - (ScoutApm::Layaway::STALE_AGE + 2)
+
+    not_stale_file_names = [File.join(data_dir, "scout_#{not_stale_time_integer}_1.data"),
+                            File.join(data_dir, "scout_#{not_stale_time_integer}_20.data")]
+    stale_file_names = [File.join(data_dir, "scout_#{stale_time_integer}_1.data"),
+                        File.join(data_dir, "scout_#{stale_time_integer}_20.data")]
+    all_file_names = not_stale_file_names + stale_file_names
+
+    (all_file_names).each do |filename|
+        File.new(filename, 'w')
+    end
+
+    assert_equal Pathname.new("/tmp/scout_apm_test/shared/scout_apm"), ScoutApm::Layaway.new(context).directory
+    assert_equal all_file_names.sort, Dir.glob("#{data_dir}/*data").sort
+
+    layaway.delete_stale_files(not_stale_time_integer - ScoutApm::Layaway::STALE_AGE)
+    assert_equal not_stale_file_names.sort, Dir.glob("#{data_dir}/*data").sort
+  end
 end


### PR DESCRIPTION
We had a customer with a `data_file` set to `/srv/appname/shared/tmp/scout_apm/`. The `scout_apm` part of the path was causing the `Layaway#timestamp_from_filename` used by `Layaway#delete_stale_files(older_than)` to pick up the wrong file name:

```
DEBUG : Deleting stale layaway files with timestamps: ["apm/scout_201803121007", "apm/scout_201803102318"
```
This PR changes the `match` regex used by `Layaway#timestamp_from_filename` which should fix the issue. This PR also adds a test for this case but for some reason the test is not running as expected. @cschneid or @alindeman mind taking a look at the test?