### PR TITLE
[Work in Progress] Supports Method#prepend for Tracer

### DIFF
--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -165,15 +165,18 @@ module ScoutApm
     end
 
     def ruby_19?
-      @ruby_19 ||= defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION.match(/^1\.9/)
+      return @ruby_19 if defined?(@ruby_19)
+      @ruby_19 = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION.match(/^1\.9/)
     end
 
     def ruby_187?
-      @ruby_187 ||= defined?(RUBY_VERSION) && RUBY_VERSION.match(/^1\.8\.7/)
+      return @ruby_187 if defined?(@ruby_187)
+      @ruby_187 = defined?(RUBY_VERSION) && RUBY_VERSION.match(/^1\.8\.7/)
     end
 
     def ruby_2?
-      @ruby_2 ||= defined?(RUBY_VERSION) && RUBY_VERSION.match(/^2/)
+      return @ruby_2 if defined?(@ruby_2)
+      @ruby_2 = defined?(RUBY_VERSION) && RUBY_VERSION.match(/^2/)
     end
 
     # Returns a string representation of the OS (ex: darwin, linux)

--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -179,6 +179,11 @@ module ScoutApm
       @ruby_2 = defined?(RUBY_VERSION) && RUBY_VERSION.match(/^2/)
     end
 
+    # Returns true if this Ruby version supports Module#prepend.
+    def supports_module_prepend?
+      ruby_2?
+    end
+
     # Returns a string representation of the OS (ex: darwin, linux)
     def os
       return @os if @os


### PR DESCRIPTION
This still needs some work and further testing, but I felt like it would be good to go ahead and get it up for review.

If supported (Ruby 2.0 and above), methods instrumented using `Tracer` will used an anonymous module `prepend`ed to the class. This means the method will appear first in the ancestor chain, and can call `super` instead of `foo_without_scout_instrument`. We want this because `Module#prepend` is usually incompatible with `alias_method_chain`, and can result in infinite loops. It should help partially res olve #114.

I want to separate this work from work on specific instruments (such as ActiveRecord) because those modifications will be less generic and need specific testing.

Some other open questions:
* Should there be a way to force `prepend` off with a configuration option? I think that's the safest way to roll this out, because users might be using _other_ gems that do not support `prepend`, but I'm not sure the best way to get access to Scout's config in `Tracer` other than calling `ScoutApm::Tracer.agent.instance.context.config`. How do folks feel about that?
* Does it fully res olve #114's specific issue, when using `ActionView` instrumentation and `jb`? I need to create a test app and try it.