### PR TITLE
[Work In Progress] Instruments #apply_join_dependency in Rails 5.2 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - "2.4"
   - "2.5"
 cache: bundler
+before_install:
+  - gem update --system
+  - gem install bundler
 jobs:
   include:
     - script: bundle exec rake test


### PR DESCRIPTION
In Rails 5.2, `ActiveRecord::FinderMethods#find_with_associations` was removed and its functionality folded into `#apply_join_dependency`. See [rails/rails#412db710](https://github.com/rails/rails/commit/412db710dfa6ed84654068576b1841966d7f89b2#diff-1cabaf53664d448a5cbfcf396cd842b1).

This is the most straightforward 'fix', but it does require a bit more investigation:
* What was the original intention of starting a layer in `find_with_associations`? Does instrumenting `apply_join_dependency` solve the same thing?
* `apply_join_dependency` is called in more places than `find_with_associations` was, including places like `Relation#to_sql` where the query may not be executed at all. Is that harmful in any way to the instrumentation?