### PR TITLE
Patch over nil -> "null" in old Rails

### DIFF
--- a/lib/scout_apm/attribute_arranger.rb
+++ b/lib/scout_apm/attribute_arranger.rb
@@ -21,6 +21,12 @@ module ScoutApm
           # serializing process)
           if data.is_a?(Time)
             attribute_hash[attribute] = data
+          elsif data.nil?
+            # Rails 3.0.x returns the string "null" when calling nil.as_json,
+            # while every newer rails returns `nil` back. We were seeing "null"
+            # as desc fields where they shouldn't have been. Force the result
+            # to be the actual type nil
+            nil
           elsif data.respond_to?(:as_json)
             attribute_hash[attribute] = data.as_json
           else


### PR DESCRIPTION
When verifying some instrumentation changes in Rails 3.0, I ran across odd
results in traces. We had many literal `"null"` strings where I expected `nil`.

I traced it to:

```
Rails 3.0.20
>> nil.as_json
=> "null"


Rails 3.2.22.5
>> nil.as_json
=> nil
```

This change makes it always behave like Rails 3.2+ (returning a nil back, not
the string)