### PR TITLE
Supports prepending exec_queries

### DIFF
--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -165,15 +165,18 @@ module ScoutApm
     end
 
     def ruby_19?
-      @ruby_19 ||= defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION.match(/^1\.9/)
+      return @ruby_19 if defined?(@ruby_19)
+      @ruby_19 = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION.match(/^1\.9/)
     end
 
     def ruby_187?
-      @ruby_187 ||= defined?(RUBY_VERSION) && RUBY_VERSION.match(/^1\.8\.7/)
+      return @ruby_187 if defined?(@ruby_187)
+      @ruby_187 = defined?(RUBY_VERSION) && RUBY_VERSION.match(/^1\.8\.7/)
     end
 
     def ruby_2?
-      @ruby_2 ||= defined?(RUBY_VERSION) && RUBY_VERSION.match(/^2/)
+      return @ruby_2 if defined?(@ruby_2)
+      @ruby_2 = defined?(RUBY_VERSION) && RUBY_VERSION.match(/^2/)
     end
 
     # Returns a string representation of the OS (ex: darwin, linux)

--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -179,6 +179,11 @@ module ScoutApm
       @ruby_2 = defined?(RUBY_VERSION) && RUBY_VERSION.match(/^2/)
     end
 
+    # Returns true if this Ruby version supports Module#prepend.
+    def supports_module_prepend?
+      ruby_2?
+    end
+
     # Returns a string representation of the OS (ex: darwin, linux)
     def os
       return @os if @os


### PR DESCRIPTION
We've seen in #114 and #186 that `alias_method_chain` style chaining and `prepend` do not mix well. Infinite loops and blown stacks often result.

This PR proposes the first steps toward supporting `Module#prepend` in instruments by `prepend`ing a module to `ActiveRecord::Relation` if `prepend` is supported. It should resolve #186.

`ActiveRecord::Relation` is a good candidate for prepending because it is a `Class` that we are prepending directly to. This is a pretty straightforward case without any edge cases that I can see.

I try to keep the duplication to a minimum, even though several new conditionals are introduced. I'm interested in how this code strikes people, and if you think there are better options.

Relates to #178 as well, though in #178 we tackle `Tracer`, rather than a specific instrument.