### PR TITLE
Calculates queue latency correctly for scheduled jobs

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Calculates DelayedJob queue latency correctly when jobs are scheduled to run in the future
+
 # 2.4.11
 
 * Adds transaction + periodic reporting callback extension support

--- a/lib/scout_apm/background_job_integrations/delayed_job.rb
+++ b/lib/scout_apm/background_job_integrations/delayed_job.rb
@@ -53,7 +53,7 @@ module ScoutApm
               req = ScoutApm::RequestManager.lookup
 
               begin
-                latency = Time.now - job.created_at
+                latency = Time.now - job.run_at
                 req.annotate_request(:queue_latency => latency)
               rescue
               end

--- a/lib/scout_apm/background_job_integrations/delayed_job.rb
+++ b/lib/scout_apm/background_job_integrations/delayed_job.rb
@@ -53,7 +53,7 @@ module ScoutApm
               req = ScoutApm::RequestManager.lookup
 
               begin
-                latency = Time.now - job.run_at
+                latency = Time.now - [job.created_at, job.run_at].max
                 req.annotate_request(:queue_latency => latency)
               rescue
               end


### PR DESCRIPTION
If a DelayedJob job is queued for future execution (`Job.delay.deliver(run_at: 5.minutes.from_now)` or via ActiveJob `Job.set(wait: 5.minutes).perform_later`), the queue latency should be calculated from the time the job was expected to run, instead of when it was created.

DelayedJob sets `run_at` to the current time if no delay is specified, so this logic should still work correctly for jobs scheduled for immediate execution.

Fixes #189