### PR TITLE
ActiveRecord query naming enhancements

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+# Head
+
+* Renames SQL `BEGIN` and `COMMIT` statements from `SQL#other` to `SQL#begin` and `SQL#commit`, respectively.
+* Makes naming between transaction and database metrics consistent. Previously, database metrics lacking a provided ActiveRecord label were named `SQL#other`.
+
 # 2.4.14
 
 * Fix database connection issue when installed in an app also using the Textacular gem

--- a/lib/scout_apm/layer_converters/database_converter.rb
+++ b/lib/scout_apm/layer_converters/database_converter.rb
@@ -13,7 +13,6 @@ module ScoutApm
 
         walker.on do |layer|
           next if skip_layer?(layer)
-
           stat = DbQueryMetricStats.new(
             model_name(layer),
             operation_name(layer),
@@ -52,23 +51,11 @@ module ScoutApm
       DEFAULT_OPERATION = "other"
 
       def model_name(layer)
-        if layer.name.respond_to?(:model)
-          layer.name.model || DEFAULT_MODEL
-        else
-          DEFAULT_MODEL
-        end
-      rescue
-        DEFAULT_MODEL
+        layer.name.to_s.split("/").first || DEFAULT_MODEL
       end
 
       def operation_name(layer)
-        if layer.name.respond_to?(:normalized_operation)
-          layer.name.normalized_operation || DEFAULT_OPERATION
-        else
-          DEFAULT_OPERATION
-        end
-      rescue
-        DEFAULT_OPERATION
+        layer.name.to_s.split("/")[1] || DEFAULT_OPERATION
       end
 
       def records_returned(layer)

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -130,7 +130,7 @@ module ScoutApm
             else
               SELECT_LABEL
             end
-          "#{match[3].gsub!(/\W/,'').classify}/#{operation}"
+          "#{match[3].gsub(/\W/,'').classify}/#{operation}"
         elsif match = UPDATE_REGEX.match(sql)
           "#{match[2].classify}/#{UPDATE_LABEL}"
         elsif match = INSERT_REGEX.match(sql)

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -12,6 +12,8 @@ module ScoutApm
       # Converts an SQL string and the name (typically assigned automatically
       # by rails) into a Scout metric_name.
       #
+      # This prefers to use the ActiveRecord-provided name over parsing SQL as parsing is slower.
+      #
       # sql: SELECT "places".* FROM "places"  ORDER BY "places"."position" ASC
       # name: Place Load
       # metric_name: Place/find
@@ -25,10 +27,12 @@ module ScoutApm
         end
       end
 
+      # This only returns a value if a name is provided via +initialize+.
       def model
         parts.first
       end
 
+      # This only returns a value if a name is provided via +initialize+.
       def normalized_operation
         parse_operation
       end
@@ -50,12 +54,14 @@ module ScoutApm
 
       private
 
+      # This only returns a value if a name is provided via +initialize+.
       def operation
         if parts.length >= 2
           parts[1].downcase
         end
       end
 
+      # This only returns a value if a name is provided via +initialize+.
       def parts
         name.split(" ")
       end

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -16,11 +16,12 @@ module ScoutApm
       # name: Place Load
       # metric_name: Place/find
       def to_s
+        return @to_s if @to_s
         parsed = parse_operation
         if parsed
-          "#{model}/#{parsed}"
+          @to_s = "#{model}/#{parsed}"
         else
-          regex_name(sql)
+          @to_s = regex_name(sql)
         end
       end
 

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -86,6 +86,8 @@ module ScoutApm
       NON_GREEDY_CONSUME = '.*?'
       TABLE = '(?:"|`)?(.*?)(?:"|`)?\s'
       COUNT = 'COUNT\(.*?\)'
+      BEGIN_STATEMENT = 'BEGIN'.freeze # BEGIN is a reserved keyword
+      COMMIT = 'COMMIT'.freeze
 
       SELECT_REGEX = /\A#{WHITE_SPACE}(SELECT)#{WHITE_SPACE}(#{COUNT})?#{NON_GREEDY_CONSUME}#{FROM}#{WHITE_SPACE}#{TABLE}/i.freeze
       UPDATE_REGEX = /\A#{WHITE_SPACE}(UPDATE)#{WHITE_SPACE}#{TABLE}/i.freeze
@@ -128,6 +130,10 @@ module ScoutApm
           "#{match[2].classify}/#{INSERT_LABEL}"
         elsif match = DELETE_REGEX.match(sql)
           "#{match[2].classify}/#{DELETE_LABEL}"
+        elsif sql == BEGIN_STATEMENT
+          "SQL/#{BEGIN_STATEMENT.downcase}"
+        elsif sql == COMMIT
+          "SQL/#{COMMIT.downcase}"
         else
           UNKNOWN_LABEL
         end

--- a/lib/scout_apm/utils/active_record_metric_name.rb
+++ b/lib/scout_apm/utils/active_record_metric_name.rb
@@ -130,7 +130,7 @@ module ScoutApm
             else
               SELECT_LABEL
             end
-          "#{match[3].classify}/#{operation}"
+          "#{match[3].gsub!(/\W/,'').classify}/#{operation}"
         elsif match = UPDATE_REGEX.match(sql)
           "#{match[2].classify}/#{UPDATE_LABEL}"
         elsif match = INSERT_REGEX.match(sql)

--- a/test/unit/utils/active_record_metric_name_test.rb
+++ b/test/unit/utils/active_record_metric_name_test.rb
@@ -64,6 +64,16 @@ class ActiveRecordMetricNameTest < Minitest::Test
     assert_equal "User/find", mn.to_s
   end
 
+  def test_begin_statement
+    mn = ScoutApm::Utils::ActiveRecordMetricName.new("BEGIN", nil)
+    assert_equal "SQL/begin", mn.to_s
+  end
+
+  def test_commit
+    mn = ScoutApm::Utils::ActiveRecordMetricName.new("COMMIT", nil)
+    assert_equal "SQL/commit", mn.to_s
+  end
+
 
   # Regex test cases, pass these in w/ "SQL" as the AR provided name field
   [
@@ -89,8 +99,6 @@ class ActiveRecordMetricNameTest < Minitest::Test
     # Stuff we don't care about in SQL
     ["SQL/other", 'SET SESSION statement_timeout = ?'],
     ["SQL/other", 'SHOW TIME ZONE'],
-    ["SQL/other", 'BEGIN'],
-    ["SQL/other", 'COMMIT'],
 
     # Empty strings, or invalid SQL
     ["SQL/other", ''],


### PR DESCRIPTION
`BEGIN` and `COMMIT` can take significant time. This identifies these queries in the metric name.

Currently, these are named `SQL/other`, which is our fallback when we're unable to come up with a label for an SQL query.