### PR TITLE
Use Monitor in Store, and add a locked section

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -6,6 +6,7 @@ end
 #####################################
 require 'cgi'
 require 'logger'
+require 'monitor'
 require 'net/http'
 require 'openssl'
 require 'pp'

--- a/lib/scout_apm/store.rb
+++ b/lib/scout_apm/store.rb
@@ -87,13 +87,15 @@ module ScoutApm
     # current-minute metrics.  Useful when we are shutting down the agent
     # during a restart.
     def write_to_layaway(layaway, force=false)
-        logger.debug("Writing to layaway#{" (Forced)" if force}")
+      logger.debug("Writing to layaway#{" (Forced)" if force}")
 
+      to_report = @mutex.synchronize {
         @reporting_periods.select { |time, rp|
-          @mutex.synchronize {
-            force || (time.timestamp < current_timestamp.timestamp)
-          }
-        }.each   { |time, rp| write_reporting_period(layaway, time, rp) }
+          force || (time.timestamp < current_timestamp.timestamp)
+        }
+      }
+
+      to_report.each { |time, rp| write_reporting_period(layaway, time, rp) }
     end
 
     # For each tick (minute), be sure we have a reporting period, and that samplers are run for it.

--- a/lib/scout_apm/store.rb
+++ b/lib/scout_apm/store.rb
@@ -5,8 +5,10 @@ module ScoutApm
   class Store
     def initialize(context)
       @context = context
-      @mutex = Mutex.new
-      @reporting_periods = Hash.new { |h,k| h[k] = StoreReportingPeriod.new(k, @context) }
+      @mutex = Monitor.new
+      @reporting_periods = Hash.new { |h,k|
+        @mutex.synchronize { h[k] = StoreReportingPeriod.new(k, @context) }
+      }
       @samplers = []
     end
 
@@ -85,10 +87,12 @@ module ScoutApm
     # current-minute metrics.  Useful when we are shutting down the agent
     # during a restart.
     def write_to_layaway(layaway, force=false)
-      logger.debug("Writing to layaway#{" (Forced)" if force}")
+      @mutex.synchronize {
+        logger.debug("Writing to layaway#{" (Forced)" if force}")
 
-      @reporting_periods.select { |time, rp| force || (time.timestamp < current_timestamp.timestamp) }.
-                         each   { |time, rp| write_reporting_period(layaway, time, rp) }
+        @reporting_periods.select { |time, rp| force || (time.timestamp < current_timestamp.timestamp) }.
+                          each   { |time, rp| write_reporting_period(layaway, time, rp) }
+      }
     end
 
     # For each tick (minute), be sure we have a reporting period, and that samplers are run for it.
@@ -98,9 +102,7 @@ module ScoutApm
     end
 
     def write_reporting_period(layaway, time, rp)
-      @mutex.synchronize {
         layaway.write_reporting_period(rp)
-      }
     rescue => e
       logger.warn("Failed writing data to layaway file: #{e.message} / #{e.backtrace}")
     ensure

--- a/lib/scout_apm/store.rb
+++ b/lib/scout_apm/store.rb
@@ -108,7 +108,7 @@ module ScoutApm
       logger.warn("Failed writing data to layaway file: #{e.message} / #{e.backtrace}")
     ensure
       logger.debug("Before delete, reporting periods length: #{@reporting_periods.size}")
-      @mutex.synchronize { deleted_items = @reporting_periods.delete(time) }
+      deleted_items = @mutex.synchronize { @reporting_periods.delete(time) }
       logger.debug("After delete, reporting periods length: #{@reporting_periods.size}. Did delete #{deleted_items}")
     end
     private :write_reporting_period


### PR DESCRIPTION
Issue #205 has a situation where the @reporting_periods hash was
updated during iteration, causing an exception. I think that the issue
is that we added a new StoreReportingPeriod during write_to_layaway
running. So we were looping and then added a new item, causing the
exception.

This wraps both in correct locks. But that was difficult with a mutex,
since you can't reobtain an already taken mutex. Monitor is the same,
but does allow that reentrant behavior, so this switches over to it.