### PR TITLE
Only annotate layer with known payload

### DIFF
--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -142,7 +142,10 @@ module ScoutApm
             req = ScoutApm::RequestManager.lookup
             layer = req.current_layer
             if layer && layer.type == "ActiveRecord"
-              layer.annotate_layer(payload)
+              layer.annotate_layer({
+                :class_name => payload[:class_name],
+                :record_count => payload[:record_count]
+              })
             elsif layer
               logger.debug("Expected layer type: ActiveRecord, got #{layer && layer.type}")
             else


### PR DESCRIPTION
Potential fix for #211 

Datadog mutates the `:payload` key in the ActiveSupport instrumentation used by both Scout and Datadog, resulting in Scout encountering unexpected data, which it then annotates to layer and eventually attempts to dump to the layaway file. Dumping fails due to the annotations containing un-marshalable `Thread::Mutex`es.

This proposes being stricter in what keys to copy from ActiveRecord instrumentation payloads and solves the problem locally for me. In addition to opening up compatibility with Datadog, it's arguably more future-proof to other types of data being added here that we may not care about.

I'm on Rails 4.2, so it may be that later Rails versions have already added keys here that Scout APM finds useable, in which case this would need to be revised.

If this approach is acceptable, please let me know if you'd like a separate PR for the v3 line.