### PR TITLE
Look also for ::Rails::VERSION to check if Rails present

### DIFF
--- a/lib/scout_apm/framework_integrations/rails_2.rb
+++ b/lib/scout_apm/framework_integrations/rails_2.rb
@@ -15,7 +15,8 @@ module ScoutApm
 
       def present?
         defined?(::Rails) &&
-          defined?(ActionController) &&
+          defined?(::Rails::VERSION) &&
+            defined?(ActionController) &&
           Rails::VERSION::MAJOR < 3
       end
 

--- a/lib/scout_apm/framework_integrations/rails_3_or_4.rb
+++ b/lib/scout_apm/framework_integrations/rails_3_or_4.rb
@@ -15,7 +15,8 @@ module ScoutApm
 
       def present?
         defined?(::Rails) &&
-          defined?(ActionController) &&
+          defined?(::Rails::VERSION) &&
+            defined?(ActionController) &&
           Rails::VERSION::MAJOR >= 3
       end
 


### PR DESCRIPTION
Hey!

At Streetbees we have a custom Sinatra API and one of the gems we use is defining the `Rails` module. Because of that, both these framework integrations would try to be loaded. That leads to errors because the `Rails` gem is not actually being installed.

After digging a bit into the code I found the `Rails::VERSION` is not defined on our app and, doing that check allows us to integrate with Scout.

Couldn't find any existing tests for `ScoutApm::FrameworkIntegrations`. If this change makes sense for you, can you show me where to add them?

Thanks!
