### PR TITLE
Read revision_sha from config (in addition to ENV)

### DIFF
--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -66,6 +66,7 @@ module ScoutApm
         'remote_agent_host',
         'remote_agent_port',
         'report_format',
+        'revision_sha',
         'scm_subdirectory',
         'uri_reporting',
         'instrument_http_url_length',

--- a/lib/scout_apm/git_revision.rb
+++ b/lib/scout_apm/git_revision.rb
@@ -17,7 +17,7 @@ module ScoutApm
     private
 
     def detect
-      detect_from_env_var    ||
+      detect_from_config     ||
       detect_from_heroku     ||
       detect_from_capistrano ||
       detect_from_git
@@ -27,8 +27,11 @@ module ScoutApm
       ENV['HEROKU_SLUG_COMMIT']
     end
 
-    def detect_from_env_var
-      ENV['SCOUT_REVISION_SHA']
+    # Config will locate the value from:
+    #   ENV variable - SCOUT_REVISION_SHA
+    #   YAML setting - revision_sha
+    def detect_from_config
+      context.config.value('revision_sha')
     end
 
     def detect_from_capistrano


### PR DESCRIPTION
For more flexibility, we can now read a user-provided SHA from the configuration system, rather than directly from the ENV. This allows a user to set the value in the YAML.