### PR TITLE
Add 'compress_payload' to coercion list

### DIFF
--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -162,6 +162,7 @@ module ScoutApm
       'database_metric_report_limit' => IntegerCoercion.new,
       'instrument_http_url_length' => IntegerCoercion.new,
       'start_resque_server_instrument' => BooleanCoercion.new,
+      'compress_payload' => BooleanCoercion.new,
     }
 
 


### PR DESCRIPTION
Closes #233 
From issue #233:
Currently, 'compress_payload' is not in coercion list.
So it's getting the literal string "false" as the value, which in ruby is a true value, so the if succeeds.