### PR TITLE
add background job support for que v0.14.3

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -60,6 +60,7 @@ require 'scout_apm/background_job_integrations/delayed_job'
 require 'scout_apm/background_job_integrations/resque'
 require 'scout_apm/background_job_integrations/shoryuken'
 require 'scout_apm/background_job_integrations/sneakers'
+require 'scout_apm/background_job_integrations/que'
 
 require 'scout_apm/framework_integrations/rails_2'
 require 'scout_apm/framework_integrations/rails_3_or_4'

--- a/lib/scout_apm/background_job_integrations/que.rb
+++ b/lib/scout_apm/background_job_integrations/que.rb
@@ -1,0 +1,130 @@
+module ScoutApm
+  module BackgroundJobIntegrations
+    class Que
+
+      UNKNOWN_CLASS_PLACEHOLDER = 'UnknownJob'.freeze
+      ACTIVE_JOB_KLASS = 'ActiveJob::QueueAdapters::QueAdapter::JobWrapper'.freeze
+      UNKNOWN_QUEUE_PLACEHOLDER = 'UnknownQueue'.freeze
+
+      attr_reader :logger
+
+      def name
+        :que
+      end
+
+      def present?
+        defined?(::Que) && File.basename($PROGRAM_NAME).start_with?('que')
+      end
+
+      def forking?
+        false
+      end
+
+      def install
+        install_tracer
+        install_worker
+        install_job
+      end
+
+      def install_tracer
+        ::Que::Job.class_eval do
+          include ScoutApm::Tracer
+        end
+      end
+
+      def install_worker
+        ::Que::Worker.class_eval do
+          def initialize_with_scout(*args)
+            agent = ::ScoutApm::Agent.instance
+            agent.start
+            initialize_without_scout(*args)
+          end
+
+          alias_method :initialize_without_scout, :initialize
+          alias_method :initialize, :initialize_with_scout
+        end
+      end
+
+      def install_job
+        ::Que::Job.class_eval do
+          # attrs = {
+          #   "queue"=>"",
+          #   "priority"=>100,
+          #   "run_at"=>2018-12-19 15:12:32 -0700,
+          #   "job_id"=>4,
+          #   "job_class"=>"ExampleJob",
+          #   "args"=>[{"key"=>"value"}],
+          #   "error_count"=>0
+          # }
+          #
+          # With ActiveJob, v0.14.3:
+          # attrs = {
+          #   "queue"=>"",
+          #   "priority"=>100,
+          #   "run_at"=>2018-12-19 15:29:18 -0700,
+          #   "job_id"=>6,
+          #   "job_class"=>"ActiveJob::QueueAdapters::QueAdapter::JobWrapper",
+          #   "args"=> [{
+          #     "job_class"=>"ExampleJob",
+          #     "job_id"=>"60798b45-4b55-436e-806d-693939266c97",
+          #     "provider_job_id"=>nil,
+          #     "queue_name"=>"default",
+          #     "priority"=>nil,
+          #     "arguments"=>[],
+          #     "executions"=>0,
+          #     "locale"=>"en"
+          #   }],
+          #   "error_count"=>0
+          # }
+          #
+          # With ActiveJob, v1.0:
+          #   There are changes here to make Que more compatible with ActiveJob
+          #   and this probably needs to be revisited.
+
+          def _run_with_scout(*args)
+            # default queue unless specifed is a blank string
+            queue = attrs['queue'] || UNKNOWN_QUEUE_PLACEHOLDER
+
+            job_class = begin
+                          if self.class == ActiveJob::QueueAdapters::QueAdapter::JobWrapper
+                            Array(attrs['args']).first['job_class'] || UNKNOWN_CLASS_PLACEHOLDER
+                          else
+                            self.class.name
+                          end
+                        rescue => e
+                          UNKNOWN_CLASS_PLACEHOLDER
+                        end
+
+            latency = begin
+                        Time.now - attrs['run_at']
+                      rescue
+                        0
+                      end
+
+            req = ScoutApm::RequestManager.lookup
+            req.annotate_request(queue_latency: latency)
+
+            begin
+              req.start_layer(ScoutApm::Layer.new('Queue', queue))
+              started_queue = true
+              req.start_layer(ScoutApm::Layer.new('Job', job_class))
+              started_job = true
+
+              _run_without_scout(*args)
+            rescue Exception => e
+              req.error!
+              raise
+            ensure
+              req.stop_layer if started_job
+              req.stop_layer if started_queue
+            end
+          end
+
+          alias_method :_run_without_scout, :_run
+          alias_method :_run, :_run_with_scout
+        end
+      end
+    end
+
+  end
+end

--- a/lib/scout_apm/background_job_integrations/que.rb
+++ b/lib/scout_apm/background_job_integrations/que.rb
@@ -102,7 +102,7 @@ module ScoutApm
                       end
 
             req = ScoutApm::RequestManager.lookup
-            req.annotate_request(queue_latency: latency)
+            req.annotate_request(:queue_latency => latency)
 
             begin
               req.start_layer(ScoutApm::Layer.new('Queue', queue))

--- a/lib/scout_apm/environment.rb
+++ b/lib/scout_apm/environment.rb
@@ -29,6 +29,7 @@ module ScoutApm
       ScoutApm::BackgroundJobIntegrations::Shoryuken.new,
       ScoutApm::BackgroundJobIntegrations::Sneakers.new,
       ScoutApm::BackgroundJobIntegrations::DelayedJob.new,
+      ScoutApm::BackgroundJobIntegrations::Que.new,
     ]
 
     FRAMEWORK_INTEGRATIONS = [


### PR DESCRIPTION
The commit adds support for Que v0.14.3. Que 1.0.0 is going to have significant changes especially relating to ActiveJob.

I have tested it locally and it appears to be working in my account. If you like it and accept it. I can deploy it on a few applications.

Please let me know if I missed anything!