### PR TITLE
Fix Travis Builds by restricting to older version of Gem & Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ rvm:
 cache: bundler
 
 before_install:
-  - gem update --system
+  # Don't gem update, since it tries to install RubyGems requiring 2.3+.
+  # - gem update --system
 
   # Lock down the version. Newer versions only support Ruby 2.3+, but we need
   # to test back further.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+
 rvm:
   - "1.8.7"
   - "1.9.3"
@@ -6,10 +7,16 @@ rvm:
   - "2.2"
   - "2.4"
   - "2.5"
+
 cache: bundler
+
 before_install:
   - gem update --system
-  - gem install bundler
+
+  # Lock down the version. Newer versions only support Ruby 2.3+, but we need
+  # to test back further.
+  - gem install bundler -v '1.17.3'
+
 jobs:
   include:
     - script: bundle exec rake test


### PR DESCRIPTION
Both RubyGems and Bundler have moved past Ruby versions 2.2 and older. They
don't work at all, and error out when installed on those older versions.

A more complete solution would be a conditional updating based on Ruby version,
but since we only barely use the features of RubyGems and Bundler, I didn't
think it was worth the hassle.