### PR TITLE
Use view instrument module#prepend whenever possible

### DIFF
--- a/lib/scout_apm/instruments/action_view.rb
+++ b/lib/scout_apm/instruments/action_view.rb
@@ -24,13 +24,18 @@ module ScoutApm
         @installed
       end
 
+      def prependable?
+        return true if context.environment.supports_module_prepend?
+        false
+      end
+
       def install
         return unless defined?(::ActionView) && defined?(::ActionView::PartialRenderer)
 
-        if defined?(::Rails) && defined?(::Rails::VERSION) && defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR < 6
-          install_using_tracer
-        else
+        if prependable?
           install_using_prepend
+        else
+          install_using_tracer
         end
         @installed = true
       end


### PR DESCRIPTION
A customer ran into an incompatibility between Scout and the `jb` gem in
ActionView. There's no reason not to use prepend whenever we can, so this
changes the check from being restricted to Rails 6+ and just opens it up to all
versions of Ruby that supports prepend, no matter the Rails version.