### PR TITLE
Add monitor false for test env

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,6 +35,9 @@ Your config file should look like:
       key: YOUR_APPLICATION_KEY
       monitor: true
 
+    test:
+      monitor: false
+
     production:
       <<: *defaults
 


### PR DESCRIPTION
Without setting the test env, we get an error:
```
Couldn't find configuration in app/config/scout_apm.yml for environment: test.
```