### PR TITLE
Add HTTP instrumentation.

### DIFF
--- a/lib/scout_apm/instruments/http.rb
+++ b/lib/scout_apm/instruments/http.rb
@@ -34,6 +34,8 @@ module ScoutApm
             def request_scout_description(verb, uri)
               max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
               (String(uri).split('?').first)[0..(max_length - 1)]
+            rescue
+              ""
             end
 
             alias request_without_scout_instruments request

--- a/lib/scout_apm/instruments/http.rb
+++ b/lib/scout_apm/instruments/http.rb
@@ -20,7 +20,7 @@ module ScoutApm
         if defined?(::HTTP) && defined?(::HTTP::Client)
           @installed = true
 
-          logger.info "Instrumenting HTTP"
+          logger.info "Instrumenting HTTP::Client"
 
           ::HTTP::Client.class_eval do
             include ScoutApm::Tracer

--- a/lib/scout_apm/instruments/http.rb
+++ b/lib/scout_apm/instruments/http.rb
@@ -1,0 +1,46 @@
+module ScoutApm
+  module Instruments
+    class HTTP
+      attr_reader :context
+
+      def initialize(context)
+        @context = context
+        @installed = false
+      end
+
+      def logger
+        context.logger
+      end
+
+      def installed?
+        @installed
+      end
+
+      def install
+        if defined?(::HTTP) && defined?(::HTTP::Client)
+          @installed = true
+
+          logger.info "Instrumenting HTTP"
+
+          ::HTTP::Client.class_eval do
+            include ScoutApm::Tracer
+
+            def request_with_scout_instruments(verb, uri, opts = {})
+              self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
+                request_without_scout_instruments(verb, uri, opts)
+              end
+            end
+
+            def request_scout_description(verb, uri)
+              max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+              (String(uri).split('?').first)[0..(max_length - 1)]
+            end
+
+            alias request_without_scout_instruments request
+            alias request request_with_scout_instruments
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/scoutapp/scout_apm_ruby/issues/258

This requires testing. I'm not aware of how this should be done, but how about something like this?

```ruby
def test_http_instrumentation
	context = ScoutApm::TestContext.new
	
	ScoutApm::Instruments::HTTP.install(context)
	
	events = context.track_events do
		HTTP.get("http://www.google.com/search?q=kittens")
	end
	
	assert_equal events, [
		["HTTP", "get", "http://www.google.com/search"]
	]
end
```

cc @dlanderson @cschneid 