### PR TITLE
Gracefully don't process LimitedLayer objects for a Detailed Trace

### DIFF
--- a/lib/scout_apm/layer_converters/trace_converter.rb
+++ b/lib/scout_apm/layer_converters/trace_converter.rb
@@ -117,7 +117,9 @@ module ScoutApm
           tags)
 
         layer.children.each do |child|
-          unless over_span_limit?(result)
+          # Don't create spans from limited layers. These don't have start/stop times and our processing can't
+          # handle these yet.
+          unless over_span_limit?(result) or child.is_a?(LimitedLayer)
             result += create_spans(child, span_id)
           end
         end
@@ -152,10 +154,8 @@ module ScoutApm
       # Limit Handling
       ################################################################################
 
-      # To prevent huge traces from being generated, we should stop collecting
+      # To prevent huge traces from being generated, we stop collecting
       # spans as we go beyond some reasonably large count.
-      # Until the root cause of https://github.com/scoutapp/scout_apm_ruby/issues/267 is addressed,
-      # keep `MAX_SPANS` less than `DEFAULT_UNIQUE_CUTOFF`.
       MAX_SPANS = 1500
 
       def over_span_limit?(spans)

--- a/lib/scout_apm/layer_converters/trace_converter.rb
+++ b/lib/scout_apm/layer_converters/trace_converter.rb
@@ -119,7 +119,7 @@ module ScoutApm
         layer.children.each do |child|
           # Don't create spans from limited layers. These don't have start/stop times and our processing can't
           # handle these yet.
-          unless over_span_limit?(result) or child.is_a?(LimitedLayer)
+          unless over_span_limit?(result) || child.is_a?(LimitedLayer)
             result += create_spans(child, span_id)
           end
         end


### PR DESCRIPTION
Fixes #267 by not processing limited layers.

Note that the exception reported in #267 only hits this issue if `DEFAULT_UNIQUE_CUTOFF` > `MAX_SPANS`. This provides additional protection. 

This is phase 2 mentioned in Slack:

![image](https://user-images.githubusercontent.com/7880/60055745-ddfdb600-969b-11e9-8ebe-382f10a71d78.png)
