### PR TITLE
ActiveRecord quick fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage/*
 lib/*.bundle
 lib/*.so
 log/scout_apm.log
+gems/*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,21 @@
 language: ruby
-
-rvm:
-  - "1.8.7"
-  - "1.9.3"
-  - "2.0"
-  - "2.2"
-  - "2.4"
-  - "2.5"
-
 cache: bundler
 
-before_install:
-  # Don't gem update, since it tries to install RubyGems requiring 2.3+.
-  # - gem update --system
-
-  # Lock down the version. Newer versions only support Ruby 2.3+, but we need
-  # to test back further.
-  - gem install bundler -v '1.17.3'
-
-jobs:
+matrix:
   include:
-    - script: bundle exec rake test
-    - script: bundle exec rubocop
-      rvm: "2.5"
+    - rvm: "1.8.7"
+      gemfile: gems/minimum.gemfile
+    - rvm: "1.9.3"
+      gemfile: gems/minimum.gemfile
+    - rvm: 2.0
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: 2.3
+    - rvm: 2.4
+    - rvm: 2.5
+    - rvm: 2.6
+    - rvm: 2.6
+      name: rubocop yo
+      script: bundle exec rubocop
+    - rvm: 2.6
+      gemfile: gems/minimum.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ cache: bundler
 matrix:
   include:
     - rvm: "1.8.7"
-      gemfile: gems/minimum.gemfile
+      gemfile: gems/rails3.gemfile
     - rvm: "1.9.3"
-      gemfile: gems/minimum.gemfile
+      gemfile: gems/rails3.gemfile
     - rvm: 2.0
-      gemfile: gems/minimum.gemfile
+      gemfile: gems/rails3.gemfile
     - rvm: 2.1
-      gemfile: gems/minimum.gemfile
+      gemfile: gems/rails3.gemfile
     - rvm: 2.2
     - rvm: 2.3
     - rvm: 2.4
@@ -22,4 +22,4 @@ matrix:
       name: rubocop yo
       script: bundle exec rubocop
     - rvm: 2.6
-      gemfile: gems/minimum.gemfile
+      gemfile: gems/rails3.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
     - rvm: 2.5
     - rvm: 2.6
     - rvm: 2.6
+      gemfile: gems/octoshark.gemfile
+    - rvm: 2.6
       name: rubocop yo
       script: bundle exec rubocop
     - rvm: 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ matrix:
     - rvm: "1.9.3"
       gemfile: gems/minimum.gemfile
     - rvm: 2.0
+      gemfile: gems/minimum.gemfile
     - rvm: 2.1
+      gemfile: gems/minimum.gemfile
     - rvm: 2.2
     - rvm: 2.3
     - rvm: 2.4

--- a/gems/README.md
+++ b/gems/README.md
@@ -1,0 +1,28 @@
+# Gems
+
+These gemfiles list specific configurations of gems that we use in travis testing.
+
+## Travis Matrix
+
+```yaml
+matrix:
+  include:
+    - rvm: "1.8.7"
+      gemfile: gems/rails3.gemfile
+```
+
+Using a gemfile controls the specific versions of the gems that are installed, and can be used to reproduce customer configurations for testing.
+
+## Local Testing
+
+To install the gems specified by a specific gemfile:
+
+```
+BUNDLE_GEMFILE=gems/rails5.gemfile bundle install
+```
+
+Then, to run tests using these gems:
+
+```
+BUNDLE_GEMFILE=gems/rails5.gemfile bundle exec rake
+```

--- a/gems/minimum.gemfile
+++ b/gems/minimum.gemfile
@@ -1,0 +1,7 @@
+
+eval_gemfile("../Gemfile")
+
+group :test do
+  gem "activerecord", "~> 3.0"
+  gem "sqlite3", "~> 1.3.6"
+end

--- a/gems/minimum.gemfile
+++ b/gems/minimum.gemfile
@@ -1,7 +1,0 @@
-
-eval_gemfile("../Gemfile")
-
-group :test do
-  gem "activerecord", "~> 3.0"
-  gem "sqlite3", "~> 1.3.6"
-end

--- a/gems/octoshark.gemfile
+++ b/gems/octoshark.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile("../Gemfile")
+
+# https://github.com/scoutapp/scout_apm_ruby/issues/217
+gem 'octoshark'

--- a/gems/rails3.gemfile
+++ b/gems/rails3.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile("../Gemfile")
+
+gem "rails", "~> 3.2"
+gem "sqlite3", "~> 1.3.5"

--- a/gems/rails4.gemfile
+++ b/gems/rails4.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile("../Gemfile")
+
+gem "rails", "~> 4.2"
+gem "sqlite3", "~> 1.3.6"

--- a/gems/rails5.gemfile
+++ b/gems/rails5.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile("../Gemfile")
+
+gem "rails", "~> 5.0"
+gem "sqlite3", "~> 1.3", ">= 1.3.6"

--- a/gems/rails6.gemfile
+++ b/gems/rails6.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile("../Gemfile")
+
+gem "rails", "~> 6.0.0rc1"
+gem "sqlite3", "~> 1.4"

--- a/scout_apm.gemspec
+++ b/scout_apm.gemspec
@@ -29,6 +29,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency "addressable"
   s.add_development_dependency "activesupport"
 
+  # These are general development dependencies which are used in instrumentation
+  # tests. Specific versions are pulled in using specific gemfiles, e.g. 
+  # `gems/rails3.gemfile`.
+  s.add_development_dependency "activerecord"
+  s.add_development_dependency "sqlite3"
+
   if RUBY_VERSION >= "1.9.3"
     s.add_development_dependency "rubocop"
     s.add_development_dependency "guard"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,7 +100,7 @@ class Minitest::Test
   end
 
   def agent_context
-    ScoutApm::AgentContext.new
+    ScoutApm::Agent.instance.context
   end
 
   DATA_FILE_DIR = File.dirname(__FILE__) + '/tmp'

--- a/test/tmp/README.md
+++ b/test/tmp/README.md
@@ -1,0 +1,17 @@
+# Temporary Data
+
+Use this directory for temporary test files.
+
+## Usage
+
+The `DATA_FILE_DIR` constant points at this directory:
+
+```ruby
+class MyTest < Minitest::Test
+  def database_path
+    File.expand_path('test.sqlite3', DATA_FILE_DIR)
+  end
+
+  # ... tests
+end
+```

--- a/test/unit/instruments/active_record_instruments_test.rb
+++ b/test/unit/instruments/active_record_instruments_test.rb
@@ -1,5 +1,0 @@
-require 'test_helper'
-
-class ActiveRecordInstrumentsTest < Minitest::Test
-end
-

--- a/test/unit/instruments/active_record_test.rb
+++ b/test/unit/instruments/active_record_test.rb
@@ -2,6 +2,12 @@ require 'test_helper'
 require 'sqlite3'
 require 'active_record'
 
+begin
+  require 'octoshark'
+rescue LoadError
+  # Ignore
+end
+
 class ActiveRecordTest < Minitest::Test
   def database_path
     File.expand_path('test.sqlite3', DATA_FILE_DIR)

--- a/test/unit/instruments/active_record_test.rb
+++ b/test/unit/instruments/active_record_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require 'sqlite3'
+require 'active_record'
+
+class ActiveRecordTest < Minitest::Test
+  def database_path
+    File.expand_path('test.sqlite3', DATA_FILE_DIR)
+  end
+
+  def setup
+    database = SQLite3::Database.new(database_path)
+    database.execute("DROP TABLE IF EXISTS users;")
+    database.execute("CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(100));")
+
+    ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => database_path)
+  end
+
+  class User < ActiveRecord::Base
+  end
+
+  def test_instrumentation
+    recorder = FakeRecorder.new
+    agent_context.recorder = recorder
+
+    instrument = ScoutApm::Instruments::ActiveRecord.new(agent_context)
+    instrument.install
+
+    ScoutApm::Tracer.instrument("Controller", "foo/bar") do
+      user = User.create
+    end
+
+    assert 1, recorder.requests.size
+  end
+end


### PR DESCRIPTION
This PR implement a quick fix and regression tests to sort out https://github.com/scoutapp/scout_apm_ruby/issues/217

I've updated the travis test matrix in order to expand our ability to test combinations of different gems using the `gems/*.gemfile` approach which I've used in the past, and implemented a very basic test case for ActiveRecord.

Finally, I discussed the best way to fix this with @cschneid and we decided that a quick fix was preferable, and the mid-term solution is to deprecate Ruby < 2.1 going forward, but that requires a bit more effort. So, this PR is good to be merged IMHO, and paves the way for 3.x.

See also https://github.com/scoutapp/scout_apm_ruby/pull/270