### PR TITLE
Legacy as_json fix for DetailedTrace spans

### DIFF
--- a/lib/scout_apm/detailed_trace.rb
+++ b/lib/scout_apm/detailed_trace.rb
@@ -98,7 +98,7 @@ class DetailedTrace
         }
       },
       :tags => tags.as_json,
-      :spans => spans.as_json,
+      :spans => spans.map{|span| span.as_json},
     }
   end
 


### PR DESCRIPTION
Rails 2.3 as_json does not recurse into objects. We were calling `as_json` on arrays of `DetailedTraceSpan`s which returned an array of `#DetailedTracesSpan` strings. Instead of calling as_json on array of detailed trace spans, map over them and call as_json on each.