### PR TITLE
Logging autoinstrument layers that are significant/insignicant + ignoring files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,4 @@ if RUBY_VERSION <= "1.8.7"
   gem "i18n", "~> 0.6.11"
   gem "pry", "~> 0.9.12"
   gem "rake", "~> 10.5"
-elsif RUBY_VERSION < "2.5.0"
-  gem "activesupport", "~> 5"
-  gem "activerecord", "~> 5"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,7 @@ if RUBY_VERSION <= "1.8.7"
   gem "i18n", "~> 0.6.11"
   gem "pry", "~> 0.9.12"
   gem "rake", "~> 10.5"
+elsif RUBY_VERSION < "2.5.0"
+  gem "activesupport", "~> 5"
+  gem "activerecord", "~> 5"
 end

--- a/lib/scout_apm/agent_context.rb
+++ b/lib/scout_apm/agent_context.rb
@@ -103,6 +103,13 @@ module ScoutApm
       @slow_job_policy ||= ScoutApm::SlowJobPolicy.new(self)
     end
 
+    # Maintains a Histogram of insignificant/significant autoinstrument layers.
+    # significant = 1
+    # insignificant = 0
+    def auto_instruments_layer_histograms
+      @auto_instruments_layer_histograms ||= ScoutApm::RequestHistograms.new
+    end
+
     # Histogram of the cumulative requests since the start of the process
     def request_histograms
       @request_histograms ||= ScoutApm::RequestHistograms.new

--- a/lib/scout_apm/auto_instrument/instruction_sequence.rb
+++ b/lib/scout_apm/auto_instrument/instruction_sequence.rb
@@ -5,15 +5,17 @@ module ScoutApm
   module AutoInstrument
     module InstructionSequence
       def load_iseq(path)
-        if Rails.controller_path?(path)
+        if Rails.controller_path?(path) & !Rails.ignore?(path)
           begin
             new_code = Rails.rewrite(path)
             return self.compile(new_code, File.basename(path), path)
           rescue
             warn "Failed to apply auto-instrumentation to #{path}: #{$!}"
           end
+        elsif Rails.ignore?(path)
+          warn "AutoInstruments are ignored for path=#{path}."
         end
-        
+
         return self.compile_file(path)
       end
     end

--- a/lib/scout_apm/auto_instrument/layer.rb
+++ b/lib/scout_apm/auto_instrument/layer.rb
@@ -1,11 +1,12 @@
 
 module ScoutApm
-  def self.AutoInstrument(name, backtrace = nil)
+  def self.AutoInstrument(name, backtrace, file_name)
     request = ScoutApm::RequestManager.lookup
 
     begin
       layer = ScoutApm::Layer.new('AutoInstrument', name)
       layer.backtrace = backtrace
+      layer.file_name = file_name
 
       request.start_layer(layer)
       started_layer = true

--- a/lib/scout_apm/auto_instrument/rails.rb
+++ b/lib/scout_apm/auto_instrument/rails.rb
@@ -60,7 +60,7 @@ module ScoutApm
           bt = ["#{file_name}:#{line}:in `#{method_name}'"]
 
           return [
-            "::ScoutApm::AutoInstrument("+ source.dump + ",#{bt}" + "){",
+            "::ScoutApm::AutoInstrument("+ source.dump + ",#{bt}" + ",'#{file_name}'" + "){",
             "}"
           ]
         end

--- a/lib/scout_apm/auto_instrument/rails.rb
+++ b/lib/scout_apm/auto_instrument/rails.rb
@@ -17,6 +17,19 @@ module ScoutApm
         CONTROLLER_FILE.match(path) && !GEM_FILE.match(path)
       end
 
+      # Autoinstruments increases overhead when applied to many code expressions that perform little work.
+      # You can exclude files from autoinstruments via the `auto_instruments_ignore` option.
+      def self.ignore?(path)
+        res = false
+        ScoutApm::Agent.instance.context.config.value('auto_instruments_ignore').each do |ignored_file_name|
+          if path.include?(ignored_file_name)
+            res = true
+            break
+          end
+        end
+        res
+      end
+
       def self.rewrite(path, code = nil)
         code ||= File.read(path)
 

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -34,6 +34,7 @@ require 'scout_apm/environment'
 # start_resque_server_instrument - Used in special situations with certain Resque installs
 # timeline_traces - true/false to enable sending of of the timeline trace format.
 # auto_instruments - true/false whether to install autoinstruments. Only installed if on a supported Ruby version.
+# auto_instruments_ignore - An array of file names to exclude from autoinstruments (Ex: ['application_controller']).
 #
 # Any of these config settings can be set with an environment variable prefixed
 # by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
@@ -77,7 +78,8 @@ module ScoutApm
         'uri_reporting',
         'instrument_http_url_length',
         'timeline_traces',
-        'auto_instruments'
+        'auto_instruments',
+        'auto_instruments_ignore'
     ]
 
     ################################################################################
@@ -171,7 +173,8 @@ module ScoutApm
       'instrument_http_url_length' => IntegerCoercion.new,
       'start_resque_server_instrument' => BooleanCoercion.new,
       'timeline_traces' => BooleanCoercion.new,
-      'auto_instruments' => BooleanCoercion.new
+      'auto_instruments' => BooleanCoercion.new,
+      'auto_instruments_ignore' => JsonCoercion.new,
     }
 
 
@@ -280,7 +283,8 @@ module ScoutApm
         'start_resque_server_instrument' => true, # still only starts if Resque is detected
         'collect_remote_ip' => true,
         'timeline_traces' => true,
-        'auto_instruments' => false
+        'auto_instruments' => false,
+        'auto_instruments_ignore' => []
       }.freeze
 
       def value(key)

--- a/lib/scout_apm/instant/middleware.rb
+++ b/lib/scout_apm/instant/middleware.rb
@@ -94,7 +94,7 @@ module ScoutApm
 
       def preconditions_met?
         if dev_trace_disabled?
-          logger.debug("DevTrace: isn't activated via config. Try: SCOUT_DEV_TRACE=true rails server")
+          # logger.debug("DevTrace: isn't activated via config. Try: SCOUT_DEV_TRACE=true rails server")
           return false
         end
 

--- a/lib/scout_apm/instant/middleware.rb
+++ b/lib/scout_apm/instant/middleware.rb
@@ -94,6 +94,7 @@ module ScoutApm
 
       def preconditions_met?
         if dev_trace_disabled?
+          # The line below is very noise as it is called on every request.
           # logger.debug("DevTrace: isn't activated via config. Try: SCOUT_DEV_TRACE=true rails server")
           return false
         end

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -38,6 +38,9 @@ module ScoutApm
     # backtrace of where it occurred.
     attr_accessor :backtrace
 
+    # The file name associated with the layer. Used for autoinstruments overhead logging.
+    attr_accessor :file_name
+
     # As we go through a part of a request, instrumentation can store additional data
     # Known Keys:
     #   :record_count - The number of rows returned by an AR query (From notification instantiation.active_record)

--- a/lib/scout_apm/layer.rb
+++ b/lib/scout_apm/layer.rb
@@ -38,7 +38,7 @@ module ScoutApm
     # backtrace of where it occurred.
     attr_accessor :backtrace
 
-    # The file name associated with the layer. Used for autoinstruments overhead logging.
+    # The file name associated with the layer. Only used for autoinstruments overhead logging.
     attr_accessor :file_name
 
     # As we go through a part of a request, instrumentation can store additional data

--- a/lib/scout_apm/periodic_work.rb
+++ b/lib/scout_apm/periodic_work.rb
@@ -24,7 +24,7 @@ module ScoutApm
       hists_summary = hists.map { |k,v|
         [
           k,
-          {total: total=v.map(&:last).inject(:+), significant: (v.last.last/total.to_f).round(2)}
+          {:total => total=v.map(&:last).inject(:+), :significant => (v.last.last/total.to_f).round(2)}
         ]
       }.to_h
       context.logger.debug("AutoInstrument Significant Layer Histograms: #{hists_summary.pretty_inspect}")

--- a/lib/scout_apm/periodic_work.rb
+++ b/lib/scout_apm/periodic_work.rb
@@ -27,7 +27,7 @@ module ScoutApm
           {total: total=v.map(&:last).inject(:+), significant: (v.last.last/total.to_f).round(2)}
         ]
       }.to_h
-      context.logger.debug("AutoInstrument Layer Histograms: #{hists_summary.pretty_inspect}")
+      context.logger.debug("AutoInstrument Significant Layer Histograms: #{hists_summary.pretty_inspect}")
     end
 
     # XXX: Move logic into a RequestHistogramsByTime class that can keep the timeout logic in it

--- a/lib/scout_apm/periodic_work.rb
+++ b/lib/scout_apm/periodic_work.rb
@@ -12,9 +12,23 @@ module ScoutApm
       ScoutApm::Debug.instance.call_periodic_hooks
       @reporting.process_metrics
       clean_old_percentiles
+      log_layer_histograms
     end
 
     private
+
+    def log_layer_histograms
+      # Ex key/value -
+      # "/Users/dlite/projects/scout/apm/app/controllers/application_controller.rb"=>[[0.0, 689], [1.0, 16]]
+      hists = context.auto_instruments_layer_histograms.as_json
+      hists_summary = hists.map { |k,v|
+        [
+          k,
+          {total: total=v.map(&:last).inject(:+), significant: (v.last.last/total.to_f).round(2)}
+        ]
+      }.to_h
+      context.logger.debug("AutoInstrument Layer Histograms: #{hists_summary.pretty_inspect}")
+    end
 
     # XXX: Move logic into a RequestHistogramsByTime class that can keep the timeout logic in it
     def clean_old_percentiles

--- a/lib/scout_apm/request_histograms.rb
+++ b/lib/scout_apm/request_histograms.rb
@@ -22,6 +22,10 @@ module ScoutApm
       @histograms.keys.each { |n| yield n }
     end
 
+    def as_json
+      @histograms.as_json
+    end
+
     def add(item, value)
       @histograms[item].add(value)
     end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -183,11 +183,12 @@ module ScoutApm
     # Returns +true+ if the total call time of AutoInstrument layers exceeds +AUTO_INSTRUMENT_TIMING_THRESHOLD+ and
     # records a Histogram of insignificant / significant layers by file name.
     def layer_insignificant?(layer)
-      result = false
+      result = false # default is significant
       if layer.type == 'AutoInstrument'
         if layer.total_call_time < AUTO_INSTRUMENT_TIMING_THRESHOLD
-          result = true
+          result = true # not significant
         end
+        # 0 = not significant, 1 = significant
         @agent_context.auto_instruments_layer_histograms.add(layer.file_name, (result ? 0 : 1))
       end
       result
@@ -235,11 +236,6 @@ module ScoutApm
     # * Send the request off to be stored
     def stop_request
       @stopping = true
-
-      if layer_finder.scope
-        # context.logger.debug("AutoInstrument Ignored Layers [#{layer_finder.scope.name}] : #{@ignored_layers.sort_by{ |k, v| v }.reverse.to_h}")
-        # context.logger.debug("AutoInstrument Kept Layers [#{layer_finder.scope.name}] : #{@kept_layers.sort_by{ |k, v| v }.reverse.to_h}")
-      end
 
       if @recorder
         @recorder.record!(self)

--- a/test/unit/auto_instrument/assignments-instrumented.rb
+++ b/test/unit/auto_instrument/assignments-instrumented.rb
@@ -1,26 +1,26 @@
 
 class Assignments
   def nested_assignment
-    @email ||= if (email = ::ScoutApm::AutoInstrument("session[\"email\"]",["BACKTRACE"]){session["email"]}).present?
-        ::ScoutApm::AutoInstrument("User.where(email: email).first",["BACKTRACE"]){User.where(email: email).first}
+    @email ||= if (email = ::ScoutApm::AutoInstrument("session[\"email\"]",["BACKTRACE"],'FILE_NAME'){session["email"]}).present?
+        ::ScoutApm::AutoInstrument("User.where(email: email).first",["BACKTRACE"],'FILE_NAME'){User.where(email: email).first}
       else
         nil
       end
   end
 
   def paginate_collection(coll)
-    page = (::ScoutApm::AutoInstrument("params[:page].present?",["BACKTRACE"]){params[:page].to_i} : 1)
-    per_page = (::ScoutApm::AutoInstrument("params[:per_page].present?",["BACKTRACE"]){params[:per_page].to_i} : 20)
-    pagination, self.collection = ::ScoutApm::AutoInstrument("pagy(...",["BACKTRACE"]){pagy(
+    page = (::ScoutApm::AutoInstrument("params[:page].present?",["BACKTRACE"],'FILE_NAME'){params[:page].to_i} : 1)
+    per_page = (::ScoutApm::AutoInstrument("params[:per_page].present?",["BACKTRACE"],'FILE_NAME'){params[:per_page].to_i} : 20)
+    pagination, self.collection = ::ScoutApm::AutoInstrument("pagy(...",["BACKTRACE"],'FILE_NAME'){pagy(
       coll,
       items: per_page,
       page: page
     )}
-    ::ScoutApm::AutoInstrument("headers[PAGINATION_TOTAL_HEADER] = pagination.count.to_s",["BACKTRACE"]){headers[PAGINATION_TOTAL_HEADER] = pagination.count.to_s}
-    ::ScoutApm::AutoInstrument("headers[PAGINATION_TOTAL_PAGES_HEADER] = pagination.pages.to_s",["BACKTRACE"]){headers[PAGINATION_TOTAL_PAGES_HEADER] = pagination.pages.to_s}
-    ::ScoutApm::AutoInstrument("headers[PAGINATION_PER_PAGE_HEADER] = per_page.to_s",["BACKTRACE"]){headers[PAGINATION_PER_PAGE_HEADER] = per_page.to_s}
-    ::ScoutApm::AutoInstrument("headers[PAGINATION_PAGE_HEADER] = pagination.page.to_s",["BACKTRACE"]){headers[PAGINATION_PAGE_HEADER] = pagination.page.to_s}
-    ::ScoutApm::AutoInstrument("headers[PAGINATION_NEXT_PAGE_HEADER] = pagination.next.to_s",["BACKTRACE"]){headers[PAGINATION_NEXT_PAGE_HEADER] = pagination.next.to_s}
-    ::ScoutApm::AutoInstrument("collection",["BACKTRACE"]){collection}
+    ::ScoutApm::AutoInstrument("headers[PAGINATION_TOTAL_HEADER] = pagination.count.to_s",["BACKTRACE"],'FILE_NAME'){headers[PAGINATION_TOTAL_HEADER] = pagination.count.to_s}
+    ::ScoutApm::AutoInstrument("headers[PAGINATION_TOTAL_PAGES_HEADER] = pagination.pages.to_s",["BACKTRACE"],'FILE_NAME'){headers[PAGINATION_TOTAL_PAGES_HEADER] = pagination.pages.to_s}
+    ::ScoutApm::AutoInstrument("headers[PAGINATION_PER_PAGE_HEADER] = per_page.to_s",["BACKTRACE"],'FILE_NAME'){headers[PAGINATION_PER_PAGE_HEADER] = per_page.to_s}
+    ::ScoutApm::AutoInstrument("headers[PAGINATION_PAGE_HEADER] = pagination.page.to_s",["BACKTRACE"],'FILE_NAME'){headers[PAGINATION_PAGE_HEADER] = pagination.page.to_s}
+    ::ScoutApm::AutoInstrument("headers[PAGINATION_NEXT_PAGE_HEADER] = pagination.next.to_s",["BACKTRACE"],'FILE_NAME'){headers[PAGINATION_NEXT_PAGE_HEADER] = pagination.next.to_s}
+    ::ScoutApm::AutoInstrument("collection",["BACKTRACE"],'FILE_NAME'){collection}
   end
 end

--- a/test/unit/auto_instrument/controller-instrumented.rb
+++ b/test/unit/auto_instrument/controller-instrumented.rb
@@ -3,47 +3,47 @@ class ClientsController < ApplicationController
   before_action :check_authorization
 
   def index
-    if ::ScoutApm::AutoInstrument("params[:status] == \"activated\"",["BACKTRACE"]){params[:status] == "activated"}
-      @clients = ::ScoutApm::AutoInstrument("Client.activated",["BACKTRACE"]){Client.activated}
+    if ::ScoutApm::AutoInstrument("params[:status] == \"activated\"",["BACKTRACE"],'FILE_NAME'){params[:status] == "activated"}
+      @clients = ::ScoutApm::AutoInstrument("Client.activated",["BACKTRACE"],'FILE_NAME'){Client.activated}
     else
-      @clients = ::ScoutApm::AutoInstrument("Client.inactivated",["BACKTRACE"]){Client.inactivated}
+      @clients = ::ScoutApm::AutoInstrument("Client.inactivated",["BACKTRACE"],'FILE_NAME'){Client.inactivated}
     end
   end
 
   def create
-    @client = ::ScoutApm::AutoInstrument("Client.new(params[:client])",["BACKTRACE"]){Client.new(params[:client])}
-    if ::ScoutApm::AutoInstrument("@client.save",["BACKTRACE"]){@client.save}
-      ::ScoutApm::AutoInstrument("redirect_to @client",["BACKTRACE"]){redirect_to @client}
+    @client = ::ScoutApm::AutoInstrument("Client.new(params[:client])",["BACKTRACE"],'FILE_NAME'){Client.new(params[:client])}
+    if ::ScoutApm::AutoInstrument("@client.save",["BACKTRACE"],'FILE_NAME'){@client.save}
+      ::ScoutApm::AutoInstrument("redirect_to @client",["BACKTRACE"],'FILE_NAME'){redirect_to @client}
     else
       # This line overrides the default rendering behavior, which
       # would have been to render the "create" view.
-      ::ScoutApm::AutoInstrument("render \"new\"",["BACKTRACE"]){render "new"}
+      ::ScoutApm::AutoInstrument("render \"new\"",["BACKTRACE"],'FILE_NAME'){render "new"}
     end
   end
 
   def edit
-    @client = ::ScoutApm::AutoInstrument("Client.new(params[:client])",["BACKTRACE"]){Client.new(params[:client])}
+    @client = ::ScoutApm::AutoInstrument("Client.new(params[:client])",["BACKTRACE"],'FILE_NAME'){Client.new(params[:client])}
 
-    if ::ScoutApm::AutoInstrument("request.post?",["BACKTRACE"]){request.post?}
-      ::ScoutApm::AutoInstrument("@client.transaction do...",["BACKTRACE"]){@client.transaction do
+    if ::ScoutApm::AutoInstrument("request.post?",["BACKTRACE"],'FILE_NAME'){request.post?}
+      ::ScoutApm::AutoInstrument("@client.transaction do...",["BACKTRACE"],'FILE_NAME'){@client.transaction do
         @client.update_attributes(params[:client])
       end}
     end
   end
 
   def data
-    @clients = ::ScoutApm::AutoInstrument("Client.all",["BACKTRACE"]){Client.all}
+    @clients = ::ScoutApm::AutoInstrument("Client.all",["BACKTRACE"],'FILE_NAME'){Client.all}
 
-    formatter = ::ScoutApm::AutoInstrument("proc do |row|...",["BACKTRACE"]){proc do |row|
+    formatter = ::ScoutApm::AutoInstrument("proc do |row|...",["BACKTRACE"],'FILE_NAME'){proc do |row|
       row.to_json
     end}
 
-    ::ScoutApm::AutoInstrument("respond_with @clients.each(&formatter).join(\"\\n\"), :content_type => 'application/json; boundary=NL'",["BACKTRACE"]){respond_with @clients.each(&formatter).join("\n"), :content_type => 'application/json; boundary=NL'}
+    ::ScoutApm::AutoInstrument("respond_with @clients.each(&formatter).join(\"\\n\"), :content_type => 'FILE_NAME'}
   end
   
   def things
     x = {}
     x[:this] ||= 'foo'
-    x[:that] &&= ::ScoutApm::AutoInstrument("'foo'.size",["BACKTRACE"]){'foo'.size}
+    x[:that] &&= ::ScoutApm::AutoInstrument("'FILE_NAME'.size}
   end
 end

--- a/test/unit/auto_instrument_test.rb
+++ b/test/unit/auto_instrument_test.rb
@@ -19,35 +19,33 @@ class AutoInstrumentTest < Minitest::Test
   # test controller.rb file, which will be different on different environments.
   # This normalizes backtraces across environments.
   def normalize_backtrace(string)
-    string.gsub(/\[".+auto_instrument\/.+?:.+?"\]/,'["BACKTRACE"]')
+    string
+      .gsub(/\[".+auto_instrument\/.+?:.+?"\]/,'["BACKTRACE"]')
+      .gsub(/'.+auto_instrument\/.+'/,"'FILE_NAME'")
   end
 
   # Use this to automatically update the test fixtures.
   def update_instrumented_source(name)
-    File.write(
-      instrumented_path(name),
-      normalize_backtrace(::ScoutApm::AutoInstrument::Rails.rewrite(source_path(name)))
-    )
+    source = ::ScoutApm::AutoInstrument::Rails.rewrite(source_path(name))
+    source = normalize_backtrace(source)
+    File.write(instrumented_path(name),source)
   end
 
   def test_controller_rewrite
+    # update_instrumented_source("controller")
     assert_equal instrumented_source("controller"),
       normalize_backtrace(::ScoutApm::AutoInstrument::Rails.rewrite(source_path("controller")))
-
-    # update_instrumented_source("controller")
   end
 
   def test_rescue_from_rewrite
+    # update_instrumented_source("rescue_from")
     assert_equal instrumented_source("rescue_from"),
       normalize_backtrace(::ScoutApm::AutoInstrument::Rails.rewrite(source_path("rescue_from")))
-
-    # update_instrumented_source("rescue_from")
   end
 
   def test_assignments_rewrite
+    # update_instrumented_source("assignments")
     assert_equal instrumented_source("assignments"),
       normalize_backtrace(::ScoutApm::AutoInstrument::Rails.rewrite(source_path("assignments")))
-
-    # update_instrumented_source("assignments")
   end
 end if defined? ScoutApm::AutoInstrument


### PR DESCRIPTION
Instrumenting many insignificant layers adds overhead. These insignificant layers are unlikely to be areas a developer will optimize. This adds a persistant Histogram that logs a count of total autoinstrumented layers and the percent significant per-file name.

In the example output below, `application_controller.rb` is potentially adding overhead as it is tracking a large number of layers and a low percentage (8%) are significant. This file can be excluded from autoinstruments via the new `autoinstruments` config option: `auto_instruments_ignore: ['application_controller']`.

```
[09/19/19 10:55:36 -0600 Dereks-MacBook-Pro.local (66345)] DEBUG : AutoInstrument Layer Histograms: {"/Users/dlite/projects/scout/apm/app/controllers/application_controller.rb"=>
  {:total=>1774, :significant=>0.08},
 "/Users/dlite/projects/scout/apm/app/controllers/status_pages_controller.rb"=>
  {:total=>5, :significant=>0.2},
 "/Users/dlite/projects/scout/apm/app/controllers/checkin_controller.rb"=>
  {:total=>52, :significant=>0.23},
 "/Users/dlite/projects/scout/apm/app/controllers/deploys_controller.rb"=>
  {:total=>15, :significant=>0.2},
 "/Users/dlite/projects/scout/apm/app/controllers/apps_controller.rb"=>
  {:total=>57, :significant=>0.46},
 "/Users/dlite/projects/scout/apm/app/controllers/errors_controller.rb"=>
  {:total=>4, :significant=>1.0},
 "/Users/dlite/projects/scout/apm/app/controllers/insights_controller.rb"=>
  {:total=>4, :significant=>1.0},
 "/Users/dlite/projects/scout/apm/app/controllers/alerts_controller.rb"=>
  {:total=>8, :significant=>0.25},
 "/Users/dlite/projects/scout/apm/app/controllers/traces_controller.rb"=>
  {:total=>12, :significant=>0.42},
 "/Users/dlite/projects/scout/apm/app/controllers/endpoints_controller.rb"=>
  {:total=>22, :significant=>0.32}}
```