### PR TITLE
Prevent potential exceptions in PeriodicWork while doing logging

### DIFF
--- a/lib/scout_apm/periodic_work.rb
+++ b/lib/scout_apm/periodic_work.rb
@@ -12,19 +12,24 @@ module ScoutApm
       ScoutApm::Debug.instance.call_periodic_hooks
       @reporting.process_metrics
       clean_old_percentiles
-      log_layer_histograms
+
+      if context.config.value('auto_instruments')
+        log_autoinstrument_significant_counts rescue nil
+      end
     end
 
     private
 
-    def log_layer_histograms
+    def log_autoinstrument_significant_counts
       # Ex key/value -
       # "/Users/dlite/projects/scout/apm/app/controllers/application_controller.rb"=>[[0.0, 689], [1.0, 16]]
       hists = context.auto_instruments_layer_histograms.as_json
-      hists_summary = hists.map { |k,v|
+      hists_summary = hists.map { |file, buckets|
+        total = buckets.map(&:last).inject(0) { |sum, count| sum + count }
+        significant = (buckets.last.last / total.to_f).round(2)
         [
-          k,
-          {:total => total=v.map(&:last).inject(:+), :significant => (v.last.last/total.to_f).round(2)}
+          file,
+          {:total => total, :significant => significant}
         ]
       }.to_h
       context.logger.debug("AutoInstrument Significant Layer Histograms: #{hists_summary.pretty_inspect}")

--- a/lib/scout_apm/request_histograms.rb
+++ b/lib/scout_apm/request_histograms.rb
@@ -23,7 +23,11 @@ module ScoutApm
     end
 
     def as_json
-      @histograms.as_json
+      Hash[
+        @histograms.map{ |key, histogram|
+          [key, histogram.as_json]
+        }
+      ]
     end
 
     def add(item, value)

--- a/test/unit/request_histograms_test.rb
+++ b/test/unit/request_histograms_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+require 'scout_apm/request_histograms'
+
+class RequestHistogramsTest < Minitest::Test
+  def test_as_json_without_activesupport
+    rh = ScoutApm::RequestHistograms.new
+
+    rh.add("foo", 1)
+    rh.add("foo", 2)
+    rh.add("bar", 3)
+
+    j = rh.as_json
+    assert_equal 2, j.size
+    assert_equal ["bar", "foo"], j.keys.sort
+  end
+end


### PR DESCRIPTION
A customer ran into an issue with log_layer_histograms in PeriodicWork
raising an exception (and hitting the rescue in BackgroundWorker,
preventing data from being reported). After some investigation it came
to light that the customer didn't have ActiveSupport in their app (a
background job worker), and so Hash#as_json wasn't being monkey patched
in.

This changes a few things:

* Renames some methods & variables in periodic work to be more clear
  about what everything is for
* Only attempt to log autoinstrument timings if autoinstruments is actually configured
* Changes the as_json call in RequestHistograms to work outside AS (also
  a test)
* devolve `inject` call to use manual summing, so it works on older
  rubies.