### PR TITLE
[WIP] Total trace time is sometimes incorrect

### DIFF
--- a/lib/scout_apm/layer_converters/slow_request_converter.rb
+++ b/lib/scout_apm/layer_converters/slow_request_converter.rb
@@ -70,7 +70,6 @@ module ScoutApm
         allocation_metric_hash = Hash.new
 
         walker.on do |layer|
-          next if skip_layer?(layer)
           store_specific_metric(layer, metric_hash, allocation_metric_hash)
           store_aggregate_metric(layer, metric_hash, allocation_metric_hash)
         end


### PR DESCRIPTION
For some reasons on v1 traces always one `SQL#other` is ignorable. I removed `skip_layer?` check and now on both versions of traces AR has the same `call_count` and response time.

Closes scoutapp/apm#628