### PR TITLE
Add additional logging to identify Marshal.dump issues

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -112,6 +112,7 @@ require 'scout_apm/utils/time'
 require 'scout_apm/utils/unique_id'
 require 'scout_apm/utils/numbers'
 require 'scout_apm/utils/gzip_helper'
+require 'scout_apm/utils/marshal_logging'
 
 require 'scout_apm/config'
 require 'scout_apm/environment'

--- a/lib/scout_apm/layaway_file.rb
+++ b/lib/scout_apm/layaway_file.rb
@@ -30,6 +30,10 @@ module ScoutApm
 
     def serialize(data)
       Marshal.dump(data)
+    rescue
+      ScoutApm::Agent.instance.logger.info("Failed Marshalling LayawayFile")
+
+      ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
     end
 
     def deserialize(data)

--- a/lib/scout_apm/remote/message.rb
+++ b/lib/scout_apm/remote/message.rb
@@ -17,6 +17,10 @@ module ScoutApm
 
       def encode
         Marshal.dump(self)
+      rescue
+        ScoutApm::Agent.instance.logger.info("Failed Marshalling Remote::Message")
+
+        ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(self).dive) rescue nil
       end
     end
   end

--- a/lib/scout_apm/serializers/app_server_load_serializer.rb
+++ b/lib/scout_apm/serializers/app_server_load_serializer.rb
@@ -5,6 +5,10 @@ module ScoutApm
     class AppServerLoadSerializer
       def self.serialize(data)
         Marshal.dump(data)
+      rescue
+        ScoutApm::Agent.instance.logger.info("Failed Marshalling AppServerLoad")
+
+        ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
       end
 
       def self.deserialize(data)

--- a/lib/scout_apm/serializers/directive_serializer.rb
+++ b/lib/scout_apm/serializers/directive_serializer.rb
@@ -5,6 +5,10 @@ module ScoutApm
     class DirectiveSerializer
       def self.serialize(data)
         Marshal.dump(data)
+      rescue
+        ScoutApm::Agent.instance.logger.info("Failed Marshalling Directive")
+
+        ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
       end
 
       def self.deserialize(data)

--- a/lib/scout_apm/utils/marshal_logging.rb
+++ b/lib/scout_apm/utils/marshal_logging.rb
@@ -1,0 +1,90 @@
+module ScoutApm
+  module Utils
+    class Error < StandardError; end
+
+    class InstanceVar
+      attr_reader :name
+      attr_reader :obj
+
+      def initialize(name, obj, parent)
+        @name = name
+        @obj = obj
+        @parent = parent
+      end
+
+      def to_s
+        "#{@name} - #{obj.class}"
+      end
+
+      def history
+        (@parent.nil? ? [] : @parent.history) + [to_s]
+      end
+    end
+
+    class MarshalLogging
+      def initialize(base_obj)
+        @base_obj = base_obj
+      end
+
+      def dive
+        to_investigate = [InstanceVar.new('Root', @base_obj, nil)]
+        max_to_check = 10000
+        checked = 0
+
+        while (var = to_investigate.shift)
+          checked += 1 
+          if checked > max_to_check
+            return "Limiting Checks (max = #{max_to_check})"
+          end
+
+          obj = var.obj
+
+          if offending_hash?(obj)
+            return "Found undumpable object: #{var.history}"
+          end
+
+          if !dumps?(obj)
+            if obj.is_a? Hash
+              keys = obj.keys
+              keys.each do |key|
+                to_investigate.push(
+                  InstanceVar.new(key.to_s, obj[key], var)
+                )
+              end
+            elsif obj.is_a? Array
+              obj.each_with_index do |value, idx|
+                to_investigate.push(
+                  InstanceVar.new("Index #{idx}", value, var)
+                )
+              end
+            else
+              symbols = obj.instance_variables
+              if !symbols.any?
+                return "Found undumpable object: #{var.history}"
+              end
+
+              symbols.each do |sym|
+                to_investigate.push(
+                  InstanceVar.new(sym, obj.instance_variable_get(sym), var)
+                )
+              end
+            end
+          end
+        end
+
+        true
+      end
+
+      def dumps?(obj)
+        Marshal.dump(obj)
+        true
+      rescue TypeError
+        false
+      end
+
+      def offending_hash?(obj)
+        obj.is_a?(Hash) && !obj.default_proc.nil?
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some data is sneaking into the Remote::Message Marshal.dump call sometimes in a
customer's environment. We're not sure what data it is though, so this change
will add more logging when an object isn't dumpable for some reason.

Currently logs at INFO level. We may need to move to DEBUG later on, although the quantity of output is pretty small.

The log output will look like:
```
Found undumpable object: ["Root - NestedThingy", "@y - Array", "Index 2 - NestedThingy", "@y - NestedThingy", "@y - Hash"]
```