### PR TITLE
Fixes Marshal.dump error in LimitedLayer

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -112,6 +112,7 @@ require 'scout_apm/utils/time'
 require 'scout_apm/utils/unique_id'
 require 'scout_apm/utils/numbers'
 require 'scout_apm/utils/gzip_helper'
+require 'scout_apm/utils/marshal_logging'
 
 require 'scout_apm/config'
 require 'scout_apm/environment'

--- a/lib/scout_apm/layaway_file.rb
+++ b/lib/scout_apm/layaway_file.rb
@@ -32,8 +32,8 @@ module ScoutApm
       Marshal.dump(data)
     rescue
       ScoutApm::Agent.instance.logger.info("Failed Marshalling LayawayFile")
-
       ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
+      raise
     end
 
     def deserialize(data)

--- a/lib/scout_apm/layaway_file.rb
+++ b/lib/scout_apm/layaway_file.rb
@@ -30,6 +30,10 @@ module ScoutApm
 
     def serialize(data)
       Marshal.dump(data)
+    rescue
+      ScoutApm::Agent.instance.logger.info("Failed Marshalling LayawayFile")
+
+      ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
     end
 
     def deserialize(data)

--- a/lib/scout_apm/layer_children_set.rb
+++ b/lib/scout_apm/layer_children_set.rb
@@ -46,9 +46,15 @@ module ScoutApm
       set = child_set(metric_type)
 
       if set.size >= unique_cutoff
-        # find limited_layer
-        @limited_layers || init_limited_layers
-        @limited_layers[metric_type].absorb(child)
+        # find or create limited_layer
+        @limited_layers ||= Hash.new 
+        layer = if @limited_layers.has_key?(metric_type)
+                  @limited_layers[metric_type]
+                else
+                  @limited_layers[metric_type] = LimitedLayer.new(metric_type)
+                end
+
+        layer.absorb(child)
       else
         # we have space just add it
         set << child
@@ -75,11 +81,6 @@ module ScoutApm
 
     def size
       @children.size
-    end
-
-    # hold off initializing this until we know we need it
-    def init_limited_layers
-      @limited_layers ||= Hash.new { |hash, key| hash[key] = LimitedLayer.new(key) }
     end
   end
 end

--- a/lib/scout_apm/remote/message.rb
+++ b/lib/scout_apm/remote/message.rb
@@ -19,8 +19,8 @@ module ScoutApm
         Marshal.dump(self)
       rescue
         ScoutApm::Agent.instance.logger.info("Failed Marshalling Remote::Message")
-
         ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(self).dive) rescue nil
+        raise
       end
     end
   end

--- a/lib/scout_apm/remote/message.rb
+++ b/lib/scout_apm/remote/message.rb
@@ -17,6 +17,10 @@ module ScoutApm
 
       def encode
         Marshal.dump(self)
+      rescue
+        ScoutApm::Agent.instance.logger.info("Failed Marshalling Remote::Message")
+
+        ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(self).dive) rescue nil
       end
     end
   end

--- a/lib/scout_apm/serializers/app_server_load_serializer.rb
+++ b/lib/scout_apm/serializers/app_server_load_serializer.rb
@@ -5,6 +5,10 @@ module ScoutApm
     class AppServerLoadSerializer
       def self.serialize(data)
         Marshal.dump(data)
+      rescue
+        ScoutApm::Agent.instance.logger.info("Failed Marshalling AppServerLoad")
+
+        ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
       end
 
       def self.deserialize(data)

--- a/lib/scout_apm/serializers/app_server_load_serializer.rb
+++ b/lib/scout_apm/serializers/app_server_load_serializer.rb
@@ -7,8 +7,8 @@ module ScoutApm
         Marshal.dump(data)
       rescue
         ScoutApm::Agent.instance.logger.info("Failed Marshalling AppServerLoad")
-
         ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
+        raise
       end
 
       def self.deserialize(data)

--- a/lib/scout_apm/serializers/directive_serializer.rb
+++ b/lib/scout_apm/serializers/directive_serializer.rb
@@ -7,8 +7,8 @@ module ScoutApm
         Marshal.dump(data)
       rescue
         ScoutApm::Agent.instance.logger.info("Failed Marshalling Directive")
-
         ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
+        raise
       end
 
       def self.deserialize(data)

--- a/lib/scout_apm/serializers/directive_serializer.rb
+++ b/lib/scout_apm/serializers/directive_serializer.rb
@@ -5,6 +5,10 @@ module ScoutApm
     class DirectiveSerializer
       def self.serialize(data)
         Marshal.dump(data)
+      rescue
+        ScoutApm::Agent.instance.logger.info("Failed Marshalling Directive")
+
+        ScoutApm::Agent.instance.logger.info(ScoutApm::Utils::MarshalLogging.new(data).dive) rescue nil
       end
 
       def self.deserialize(data)

--- a/lib/scout_apm/utils/marshal_logging.rb
+++ b/lib/scout_apm/utils/marshal_logging.rb
@@ -1,0 +1,90 @@
+module ScoutApm
+  module Utils
+    class Error < StandardError; end
+
+    class InstanceVar
+      attr_reader :name
+      attr_reader :obj
+
+      def initialize(name, obj, parent)
+        @name = name
+        @obj = obj
+        @parent = parent
+      end
+
+      def to_s
+        "#{@name} - #{obj.class}"
+      end
+
+      def history
+        (@parent.nil? ? [] : @parent.history) + [to_s]
+      end
+    end
+
+    class MarshalLogging
+      def initialize(base_obj)
+        @base_obj = base_obj
+      end
+
+      def dive
+        to_investigate = [InstanceVar.new('Root', @base_obj, nil)]
+        max_to_check = 10000
+        checked = 0
+
+        while (var = to_investigate.shift)
+          checked += 1 
+          if checked > max_to_check
+            return "Limiting Checks (max = #{max_to_check})"
+          end
+
+          obj = var.obj
+
+          if offending_hash?(obj)
+            return "Found undumpable object: #{var.history}"
+          end
+
+          if !dumps?(obj)
+            if obj.is_a? Hash
+              keys = obj.keys
+              keys.each do |key|
+                to_investigate.push(
+                  InstanceVar.new(key.to_s, obj[key], var)
+                )
+              end
+            elsif obj.is_a? Array
+              obj.each_with_index do |value, idx|
+                to_investigate.push(
+                  InstanceVar.new("Index #{idx}", value, var)
+                )
+              end
+            else
+              symbols = obj.instance_variables
+              if !symbols.any?
+                return "Found undumpable object: #{var.history}"
+              end
+
+              symbols.each do |sym|
+                to_investigate.push(
+                  InstanceVar.new(sym, obj.instance_variable_get(sym), var)
+                )
+              end
+            end
+          end
+        end
+
+        true
+      end
+
+      def dumps?(obj)
+        Marshal.dump(obj)
+        true
+      rescue TypeError
+        false
+      end
+
+      def offending_hash?(obj)
+        obj.is_a?(Hash) && !obj.default_proc.nil?
+      end
+    end
+  end
+end

--- a/test/unit/layer_children_set_test.rb
+++ b/test/unit/layer_children_set_test.rb
@@ -71,6 +71,15 @@ class LayerChildrenSetTest < Minitest::Test
     limited_layers.each { |ml| assert_equal 5, ml.count }
   end
 
+  def test_works_with_marshal
+    s = SET.new(5)
+    10.times do
+      s << make_layer("LayerType", "LayerName")
+    end
+
+    Marshal.dump(s)
+  end
+
   #############
   #  Helpers  #
   #############


### PR DESCRIPTION
This was exposed in the Resque instruments, after collecting data for a job it
ships it via a loopback HTTP server, with Marshal.dump as the serialization.

LimitedLayer had a Hash.new, with a default proc, causing the serialization to fail.

This PR also adds much better debug logging in the face of Marshal.dump errors, digging
into exactly what failed to dump, rather than the default ¯\\_(ツ)_/¯ from Ruby.