### PR TITLE
Fix typo when calling `queue_time_ms`

### DIFF
--- a/lib/scout_apm/extensions/transaction_callback_payload.rb
+++ b/lib/scout_apm/extensions/transaction_callback_payload.rb
@@ -26,7 +26,7 @@ module ScoutApm
       # The time in queue of the transaction in ms. If not present, +nil+ is returned as this is unknown.
       def queue_time_ms
         # Controller logic
-        if converter_results[:queue_time] && converter_results[:queue].any?
+        if converter_results[:queue_time] && converter_results[:queue_time].any?
           converter_results[:queue_time].values.first.total_call_time*1000 # ms
         # Job logic
         elsif converter_results[:job]


### PR DESCRIPTION
* In a TrackedRequest, the `queue_time` is present, but the `queue` is
	`nil` (because we don't know what the queue is, just that we've been
	given a queue time via a request header)