### PR TITLE
preload celluloid before shoryken processor

### DIFF
--- a/lib/scout_apm/background_job_integrations/shoryuken.rb
+++ b/lib/scout_apm/background_job_integrations/shoryuken.rb
@@ -37,6 +37,8 @@ module ScoutApm
       end
 
       def install_processor
+        # celluloid has not loaded by this point and older versions of `shorykuen/processor` assume that it did
+        require 'celluloid' if defined?(::Shoryuken::VERSION) && ::Shoryuken::VERSION < '3'
         require 'shoryuken/processor' # sidekiq v4 has not loaded this file by this point
 
         ::Shoryuken::Processor.class_eval do


### PR DESCRIPTION
This resolves the following issue that we bumped into when using scout_apm in conjunction with shoryuken.

```ruby
uninitialized constant Shoryuken::Processor::Celluloid
```

```
/usr/local/rvm/gems/ruby-2.4.5/gems/shoryuken-2.0.2/lib/shoryuken/processor.rb:5:in `<class:Processor>'
/usr/local/rvm/gems/ruby-2.4.5/gems/shoryuken-2.0.2/lib/shoryuken/processor.rb:4:in `<module:Shoryuken>'
/usr/local/rvm/gems/ruby-2.4.5/gems/shoryuken-2.0.2/lib/shoryuken/processor.rb:3:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.4.5/gems/scout_apm-2.6.6/lib/scout_apm/background_job_integrations/shoryuken.rb:40:in install_processor'
/usr/local/rvm/gems/ruby-2.4.5/gems/scout_apm-2.6.6/lib/scout_apm/background_job_integrations/shoryuken.rb:21:in `install'
```