### PR TITLE
Fix Rails 6 Deprecation Warning 

### DIFF
--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -17,44 +17,61 @@ module ScoutApm
         @installed
       end
 
-      def install
-        # We previously instrumented ActionController::Metal, which missed
-        # before and after filter timing. Instrumenting Base includes those
-        # filters, at the expense of missing out on controllers that don't use
-        # the full Rails stack.
-        if defined?(::ActionController)
-          @installed = true
+      def installed!
+        @installed = true
+      end
 
+      def install
+        if !defined?(::ActiveSupport)
+          return
+        end
+
+        # The block below runs with `self` equal to the ActionController::Base or ::API module, not this class we're in now. By saving an instance of ourselves into the `this` variable, we can continue accessing what we need.
+        this = self
+
+        ActiveSupport.on_load(:action_controller) do
+          if this.installed?
+            this.logger.info("Skipping ActionController - Already Ran")
+            next
+          else
+            this.logger.info("Instrumenting ActionController (on_load)")
+            this.installed!
+          end
+
+          # We previously instrumented ActionController::Metal, which missed
+          # before and after filter timing. Instrumenting Base includes those
+          # filters, at the expense of missing out on controllers that don't use
+          # the full Rails stack.
           if defined?(::ActionController::Base)
-            logger.info "Instrumenting ActionController::Base"
+            this.logger.info "Instrumenting ActionController::Base"
             ::ActionController::Base.class_eval do
-              # include ScoutApm::Tracer
               include ScoutApm::Instruments::ActionControllerBaseInstruments
             end
           end
 
           if defined?(::ActionController::Metal)
-            logger.info "Instrumenting ActionController::Metal"
+            this.logger.info "Instrumenting ActionController::Metal"
             ::ActionController::Metal.class_eval do
               include ScoutApm::Instruments::ActionControllerMetalInstruments
             end
           end
 
           if defined?(::ActionController::API)
-            logger.info "Instrumenting ActionController::Api"
+            this.logger.info "Instrumenting ActionController::Api"
             ::ActionController::API.class_eval do
               include ScoutApm::Instruments::ActionControllerAPIInstruments
             end
           end
         end
 
-        # Returns a new anonymous module each time it is called. So
-        # we can insert this multiple times into the ancestors
-        # stack. Otherwise it only exists the first time you include it
-        # (under Metal, instead of under API) and we miss instrumenting
-        # before_action callbacks
+        ScoutApm::Agent.instance.context.logger.info("Instrumenting ActionController (hook installed)")
       end
 
+      # Returns a new anonymous module each time it is called. So
+      # we can insert this multiple times into the ancestors
+      # stack. Otherwise it only exists the first time you include it
+      # (under Metal, instead of under API) and we miss instrumenting
+      # before_action callbacks
       def self.build_instrument_module
         Module.new do
           def process_action(*args)


### PR DESCRIPTION
The instrumentation referenced ActionController::Base at boot, which triggered a deprecation warning in the Rails 6 autoloader. This now wraps it in the proper ActiveSupport.on_load call.