### PR TITLE
Fix Sidekiq 6.1.0's changed signature on Processor#initialize

### DIFF
--- a/lib/scout_apm/background_job_integrations/sidekiq.rb
+++ b/lib/scout_apm/background_job_integrations/sidekiq.rb
@@ -40,10 +40,10 @@ module ScoutApm
         require 'sidekiq/processor' # sidekiq v4 has not loaded this file by this point
 
         ::Sidekiq::Processor.class_eval do
-          def initialize_with_scout(boss)
+          def initialize_with_scout(*args)
             agent = ::ScoutApm::Agent.instance
             agent.start
-            initialize_without_scout(boss)
+            initialize_without_scout(*args)
           end
 
           alias_method :initialize_without_scout, :initialize


### PR DESCRIPTION
Currently on the (yet-unreleased, on master branch) Sidekiq 6.1, the Processor#initialize method signature has changed to add a new options argument. We don't care about the argument at all, and just want to be sure Scout starts at boot time, so pass through whatever is handed to us via `*args` instead of having any knowledge of the signature.

I have verified that Sidekiq now boots against both 6.1 and the released 6.0.7 versions. I have not done full path testing of Sidekiq 6.1 to verify all of our other instruments work as expected, but we rely on standard sidekiq middleware and I doubt that API has changed drastically.

Fixes #340 