### PR TITLE
User override of captured URI on Controllers

### DIFF
--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -74,8 +74,7 @@ module ScoutApm
       # before_action callbacks
       def self.build_instrument_module
         Module.new do
-          # Given an +ActionDispatch::Request+, formats the uri based on config settings.
-          # XXX: Don't lookup context like this - find a way to pass it through
+          # Determine the URI of this request to capture. Overridable by users in their controller.
           def scout_transaction_uri(config=ScoutApm::Agent.instance.context.config)
             case config.value("uri_reporting")
             when 'path'
@@ -100,7 +99,6 @@ module ScoutApm
               # Don't start a new layer if ActionController::API or ActionController::Base handled it already.
               super
             else
-              # This is overridable by the user on a per-controller basis
               begin
                 uri = scout_transaction_uri
                 req.annotate_request(:uri => uri)

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -74,6 +74,17 @@ module ScoutApm
       # before_action callbacks
       def self.build_instrument_module
         Module.new do
+          # Given an +ActionDispatch::Request+, formats the uri based on config settings.
+          # XXX: Don't lookup context like this - find a way to pass it through
+          def scout_transaction_uri(config=ScoutApm::Agent.instance.context.config)
+            case config.value("uri_reporting")
+            when 'path'
+              request.path # strips off the query string for more security
+            else # default handles filtered params
+              request.filtered_path
+            end
+          end
+
           def process_action(*args)
             req = ScoutApm::RequestManager.lookup
             current_layer = req.current_layer
@@ -89,7 +100,12 @@ module ScoutApm
               # Don't start a new layer if ActionController::API or ActionController::Base handled it already.
               super
             else
-              req.annotate_request(:uri => ScoutApm::Instruments::ActionControllerRails3Rails4.scout_transaction_uri(request))
+              # This is overridable by the user on a per-controller basis
+              begin
+                uri = scout_transaction_uri
+                req.annotate_request(:uri => uri)
+              rescue
+              end
 
               # IP Spoofing Protection can throw an exception, just move on w/o remote ip
               if agent_context.config.value('collect_remote_ip')
@@ -112,16 +128,6 @@ module ScoutApm
         end
       end
 
-      # Given an +ActionDispatch::Request+, formats the uri based on config settings.
-      # XXX: Don't lookup context like this - find a way to pass it through
-      def self.scout_transaction_uri(request, config=ScoutApm::Agent.instance.context.config)
-        case config.value("uri_reporting")
-        when 'path'
-          request.path # strips off the query string for more security
-        else # default handles filtered params
-          request.filtered_path
-        end
-      end
     end
 
     module ActionControllerMetalInstruments


### PR DESCRIPTION
Scout captures the incoming URI and stores it for viewing on traces. There
are 2 pre-existing built in security modes, one that captures the whole
thing, and one that trims off any query params (?foo=bar)

But some users have more advanced needs for manipulating the URI before
capturing. Typically these involve times where personally identifiable
info gets put into the URL itself. The motivating example of this is
a url that looks something like /users/chris@scoutapm.com/dashboard.

The customer with that URL doesn't want to send all of their customer's
email addresses up, but also doesn't want to give up uri capturing
generally.

The new API is to override the `scout_transaction_uri` function in
the controller, returning a string with the modified uri. To get the
built in version, call `super`.

For instance:

```ruby
def scout_transaction_uri
  if action_name == "show"
    request.path.gsub(/\d+/, ":id")
  else
    super
  end
end
```