### PR TITLE
Fix a handful of Ruby 2.7 deprecation warnings

### DIFF
--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -408,7 +408,7 @@ module ScoutApm
     end
 
     module ActiveRecordUpdateInstruments
-      def save(*args, &block)
+      def save(*args, **options, &block)
         model = self.class.name
         operation = self.persisted? ? "Update" : "Create"
 
@@ -418,14 +418,14 @@ module ScoutApm
         req.start_layer(layer)
         req.ignore_children!
         begin
-          super(*args, &block)
+          super(*args, **options, &block)
         ensure
           req.acknowledge_children!
           req.stop_layer
         end
       end
 
-      def save!(*args, &block)
+      def save!(*args, **options, &block)
         model = self.class.name
         operation = self.persisted? ? "Update" : "Create"
 
@@ -434,7 +434,7 @@ module ScoutApm
         req.start_layer(layer)
         req.ignore_children!
         begin
-          super(*args, &block)
+          super(*args, **options, &block)
         ensure
           req.acknowledge_children!
           req.stop_layer

--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -323,14 +323,14 @@ module ScoutApm
         end
       end
 
-      def find_by_sql_with_scout_instruments(*args, &block)
+      def find_by_sql_with_scout_instruments(*args, **kwargs, &block)
         req = ScoutApm::RequestManager.lookup
         layer = ScoutApm::Layer.new("ActiveRecord", Utils::ActiveRecordMetricName::DEFAULT_METRIC)
         layer.annotate_layer(:ignorable => true)
         req.start_layer(layer)
         req.ignore_children!
         begin
-          find_by_sql_without_scout_instruments(*args, &block)
+          find_by_sql_without_scout_instruments(*args, **kwargs, &block)
         ensure
           req.acknowledge_children!
           req.stop_layer


### PR DESCRIPTION
This pull request resolves three deprecation warnings seen when using the latest version of scout_apm (v2.6.9) with Ruby 2.7.1.

4c7ac9f94fd99b1e94fdeb1b09b41d7099b9e19c resolves the specific warning cited in https://github.com/scoutapp/scout_apm_ruby/issues/319. This warning is seen when using `ActiveRecord::Querying.find_by_sql`:

    gems/scout_apm-2.6.9/lib/scout_apm/instruments/active_record.rb:333: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    gems/activerecord-6.0.3.3/lib/active_record/querying.rb:45: warning: The called method `find_by_sql_without_scout_instruments' is defined here

1aa5f92e1a787da122167fcba425c44f59ebe440 resolves the following warnings seen using `ActiveRecord::Persistence#save` and `ActiveRecord::Persistence#save!`:

    gems/scout_apm-2.6.9/lib/scout_apm/instruments/active_record.rb:421: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    gems/activerecord-6.0.3.3/lib/active_record/suppressor.rb:43: warning: The called method `save' is defined here

    gems/scout_apm-2.6.9/lib/scout_apm/instruments/active_record.rb:437: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    gems/activerecord-6.0.3.3/lib/active_record/suppressor.rb:47: warning: The called method `save!' is defined here

In all of these cases, the ActiveRecord method accepts a combination of positional args and keyword args. We can resolve these warnings by updating the method signatures in scout_apm to 1) accept the same combination of positional args and keyword args, and 2) pass along those positional args and keyword args when invoking the corresponding method in ActiveRecord.


