### PR TITLE
Remove many more keys from ENV captured by errors

### DIFF
--- a/lib/scout_apm/error_service/error_record.rb
+++ b/lib/scout_apm/error_service/error_record.rb
@@ -89,11 +89,16 @@ module ScoutApm
       end
 
       # Deletes params from env
+      #
+      # These are not configurable, and will leak PII info up to Scout if
+      # allowed through. Things like specific parameters can be exposed with
+      # the ScoutApm::Context interface.
       KEYS_TO_REMOVE = [
         "rack.request.form_hash",
         "rack.request.form_vars",
         "async.callback",
 
+        # Security related items
         "action_dispatch.secret_key_base",
         "action_dispatch.http_auth_salt",
         "action_dispatch.signed_cookie_salt",
@@ -101,6 +106,7 @@ module ScoutApm
         "action_dispatch.encrypted_signed_cookie_salt",
         "action_dispatch.authenticated_encrypted_cookie_salt",
 
+        # Raw data from the URL & parameters. Would bypass our normal params filtering
         "QUERY_STRING",
         "REQUEST_URI",
         "REQUEST_PATH",
@@ -111,7 +117,6 @@ module ScoutApm
         "rack.request.query_hash",
       ]
       def strip_env(env)
-        binding.pry
         env.reject { |k, v| KEYS_TO_REMOVE.include?(k) }
       end
 

--- a/lib/scout_apm/error_service/error_record.rb
+++ b/lib/scout_apm/error_service/error_record.rb
@@ -88,10 +88,30 @@ module ScoutApm
         end
       end
 
-      # Deletes params from env / set in config file
-      # TODO: Make sure this is fast enough - I don't think we want to duplicate the entirity of env? (which reject does)
-      KEYS_TO_REMOVE = ["rack.request.form_hash", "rack.request.form_vars", "async.callback"]
+      # Deletes params from env
+      KEYS_TO_REMOVE = [
+        "rack.request.form_hash",
+        "rack.request.form_vars",
+        "async.callback",
+
+        "action_dispatch.secret_key_base",
+        "action_dispatch.http_auth_salt",
+        "action_dispatch.signed_cookie_salt",
+        "action_dispatch.encrypted_cookie_salt",
+        "action_dispatch.encrypted_signed_cookie_salt",
+        "action_dispatch.authenticated_encrypted_cookie_salt",
+
+        "QUERY_STRING",
+        "REQUEST_URI",
+        "REQUEST_PATH",
+        "ORIGINAL_FULLPATH",
+        "action_dispatch.request.query_parameters",
+        "action_dispatch.request.parameters",
+        "rack.request.query_string",
+        "rack.request.query_hash",
+      ]
       def strip_env(env)
+        binding.pry
         env.reject { |k, v| KEYS_TO_REMOVE.include?(k) }
       end
 


### PR DESCRIPTION
Remove many more keys from ENV that are related to raw URL data (potential PII leak), and security (should never leave the host system)