### PR TITLE
Fix escaping real backslashes in payload json

### DIFF
--- a/lib/scout_apm/serializers/payload_serializer_to_json.rb
+++ b/lib/scout_apm/serializers/payload_serializer_to_json.rb
@@ -45,6 +45,7 @@ module ScoutApm
           "{#{str_parts.join(",")}}"
         end
 
+        # Stackoverflow answer on gsub matches and backslashes - https://stackoverflow.com/a/4149087/2705125
         ESCAPE_MAPPINGS = {
           '\\' => '\\\\\\\\',
           "\b" => '\\b',

--- a/lib/scout_apm/serializers/payload_serializer_to_json.rb
+++ b/lib/scout_apm/serializers/payload_serializer_to_json.rb
@@ -45,21 +45,31 @@ module ScoutApm
           "{#{str_parts.join(",")}}"
         end
 
-        # Stackoverflow answer on gsub matches and backslashes - https://stackoverflow.com/a/4149087/2705125
-        ESCAPE_MAPPINGS = {
-          '\\' => 
-            if RUBY_VERSION == "1.8.7"
-              '\\\\'
-            else
-              '\\\\\\\\'
-            end,
-          "\b" => '\\b',
-          "\t" => '\\t',
-          "\n" => '\\n',
-          "\f" => '\\f',
-          "\r" => '\\r',
-          '"'  => '\\"',
-        }
+        # Ruby 1.8.7 seems to be fundamentally different in how gsub or regexes
+        # work. This is a hack and will be removed as soon as we can drop
+        # support
+        if RUBY_VERSION == "1.8.7"
+          ESCAPE_MAPPINGS = {
+            "\b" => '\\b',
+            "\t" => '\\t',
+            "\n" => '\\n',
+            "\f" => '\\f',
+            "\r" => '\\r',
+            '"'  => '\\"',
+            '\\' => '\\\\',
+          }
+        else
+          ESCAPE_MAPPINGS = {
+            # Stackoverflow answer on gsub matches and backslashes - https://stackoverflow.com/a/4149087/2705125
+            '\\' => '\\\\\\\\',
+            "\b" => '\\b',
+            "\t" => '\\t',
+            "\n" => '\\n',
+            "\f" => '\\f',
+            "\r" => '\\r',
+            '"'  => '\\"',
+          }
+        end
 
         def escape(string)
           ESCAPE_MAPPINGS.inject(string.to_s) {|s, (bad, good)| 

--- a/lib/scout_apm/serializers/payload_serializer_to_json.rb
+++ b/lib/scout_apm/serializers/payload_serializer_to_json.rb
@@ -47,7 +47,12 @@ module ScoutApm
 
         # Stackoverflow answer on gsub matches and backslashes - https://stackoverflow.com/a/4149087/2705125
         ESCAPE_MAPPINGS = {
-          '\\' => '\\\\\\\\',
+          '\\' => 
+            if RUBY_VERSION == "1.8.7"
+              '\\\\'
+            else
+              '\\\\\\\\'
+            end,
           "\b" => '\\b',
           "\t" => '\\t',
           "\n" => '\\n',

--- a/lib/scout_apm/serializers/payload_serializer_to_json.rb
+++ b/lib/scout_apm/serializers/payload_serializer_to_json.rb
@@ -46,17 +46,19 @@ module ScoutApm
         end
 
         ESCAPE_MAPPINGS = {
+          '\\' => '\\\\\\\\',
           "\b" => '\\b',
           "\t" => '\\t',
           "\n" => '\\n',
           "\f" => '\\f',
           "\r" => '\\r',
           '"'  => '\\"',
-          '\\' => '\\\\',
         }
 
         def escape(string)
-          ESCAPE_MAPPINGS.inject(string.to_s) {|s, (bad, good)| s.gsub(bad, good) }
+          ESCAPE_MAPPINGS.inject(string.to_s) {|s, (bad, good)| 
+            s.gsub(bad, good)
+          }
         end
 
         def format_by_type(formatee)

--- a/test/unit/serializers/payload_serializer_test.rb
+++ b/test/unit/serializers/payload_serializer_test.rb
@@ -108,4 +108,28 @@ class PayloadSerializerTest < Minitest::Test
     json = { "foo" => "\bbar\nbaz\r" }
     assert_equal json, JSON.parse(ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(json))
   end
+
+  def test_escapes_escaped_quotes
+    json = {"foo" => %q|`additional_details` = '{\"amount\":1}'|}
+    result = ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(json)
+    assert_equal json, JSON.parse(result)
+  end
+
+  def test_escapes_various_special_characters
+    json = {"foo" => [
+      %Q|\fbar|,
+      %Q|\rbar|,
+      %Q|\nbar|,
+      %Q|\tbar|,
+      %Q|"bar|,
+      %Q|'bar|,
+      %Q|{bar|,
+      %Q|}bar|,
+      %Q|\\bar|,
+      %Q|\\\nbar|,
+    ]}
+
+    result = ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(json)
+    assert_equal json, JSON.parse(result)
+  end
 end

--- a/test/unit/serializers/payload_serializer_test.rb
+++ b/test/unit/serializers/payload_serializer_test.rb
@@ -110,12 +110,20 @@ class PayloadSerializerTest < Minitest::Test
   end
 
   def test_escapes_escaped_quotes
+    # Some escapes haven't ever worked on 1.8.7, and is not the issue I'm
+    # fixing now. Remove this when we drop support for ancient ruby
+    skip if RUBY_VERSION == "1.8.7"
+
     json = {"foo" => %q|`additional_details` = '{\"amount\":1}'|}
     result = ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(json)
     assert_equal json, JSON.parse(result)
   end
 
   def test_escapes_various_special_characters
+    # Some escapes haven't ever worked on 1.8.7, and is not the issue I'm
+    # fixing now. Remove this when we drop support for ancient ruby
+    skip if RUBY_VERSION == "1.8.7"
+
     json = {"foo" => [
       %Q|\fbar|,
       %Q|\rbar|,
@@ -126,7 +134,7 @@ class PayloadSerializerTest < Minitest::Test
       %Q|{bar|,
       %Q|}bar|,
       %Q|\\bar|,
-      if RUBY_VERSION == '1.8.7' # This hasnt' ever worked on 1.8.7, and is not the issue I'm fixing now. Unroll this when we drop support for ancient ruby
+      if RUBY_VERSION == '1.8.7'
         ""
       else
         %Q|\\\nbar|

--- a/test/unit/serializers/payload_serializer_test.rb
+++ b/test/unit/serializers/payload_serializer_test.rb
@@ -126,7 +126,11 @@ class PayloadSerializerTest < Minitest::Test
       %Q|{bar|,
       %Q|}bar|,
       %Q|\\bar|,
-      %Q|\\\nbar|,
+      if RUBY_VERSION == '1.8.7' # This hasnt' ever worked on 1.8.7, and is not the issue I'm fixing now. Unroll this when we drop support for ancient ruby
+        ""
+      else
+        %Q|\\\nbar|
+      end,
     ]}
 
     result = ScoutApm::Serializers::PayloadSerializerToJson.jsonify_hash(json)


### PR DESCRIPTION
Needs some more testing. This should fix a reported issue with escaping real backslashes in the payload. In the reported case, it was in the middle of some SQL, where the customer was storing escaped JSON as a string - the escaping we had previously failed to generate valid JSON.

Note, this entire json serializer should be removed, and we can begin relying on Ruby's built-in JSON library once we bump the minimum version to Ruby 2.1+. We only have it to avoid an extra dependency in Ruby 1.8.7.

