### PR TITLE
Resolve Rails 6.1 deprecation warning re: connection_config

### DIFF
--- a/lib/scout_apm/framework_integrations/rails_3_or_4.rb
+++ b/lib/scout_apm/framework_integrations/rails_3_or_4.rb
@@ -71,7 +71,11 @@ module ScoutApm
       #
       # We avoid this issue by not calling .respond_to? here, and instead using the less optimal `rescue nil` approach
       def raw_database_adapter
-        adapter = ActiveRecord::Base.connection_config[:adapter].to_s rescue nil
+        adapter = ActiveRecord::Base.connection_db_config.configuration_hash[:adapter] rescue nil
+
+        if adapter.nil?
+          adapter = ActiveRecord::Base.connection_config[:adapter].to_s rescue nil
+        end
 
         if adapter.nil?
           adapter = ActiveRecord::Base.configurations[env]["adapter"]


### PR DESCRIPTION
Prior to this change, the first interaction with the database would emit the following deprecation warning with Rails 6.1:

> DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead)

The deprecation was introduced in https://github.com/rails/rails/pull/38005 and includes the following [release notes](https://github.com/rails/rails/pull/38005/files#diff-353f4f101b1bb04938d761b6e29c88e0f147084e9e276854a77ae5d9a9a3b2a8):

> The `connection_config` method has been deprecated, please use `connection_db_config` instead which will return a `DatabaseConfigurations::DatabaseConfig` instead of a `Hash`.

### Proposed resolution

With the changes in the pull request, Scout first attempts to use `connection_db_config`. If unsuccessful, Scout falls back to the previous behavior of using `connection_config`.

### How to reproduce the deprecation warning

1. Verify you're using Rails 6.1:

    ```
    $ rails -v
    Rails 6.1.0
    ```

2. Set up a new Rails app with scout_apm:

    ```
    $ rails new sample --database=postgresql
    $ cd sample/
    $ rails db:create
    $ rails generate model User name:string
    $ rails db:migrate
    $ bundle add scout_apm 
    ```

3. Load Scout and interact with the database:

    ```
    $ SCOUT_DEV_TRACE=true rails console

    2.7.2-p137> User.count
    DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead) (called from irb_binding at (irb):1)
      (0.4ms)  SELECT COUNT(*) FROM "users"
    => 0
    ```
