### PR TITLE
Update required_ruby_version to allow ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ matrix:
       script: bundle exec rubocop
     - rvm: 2.6
       gemfile: gems/rails3.gemfile
+    - rvm: 3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: trusty
+dist: xenial
 cache: bundler
 
 matrix:

--- a/scout_apm.gemspec
+++ b/scout_apm.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.extensions << 'ext/allocations/extconf.rb'
   s.extensions << 'ext/rusage/extconf.rb'
 
-  s.required_ruby_version = '~> 2.1'
+  s.required_ruby_version = '>= 2.1'
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "mocha"
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "parser"
 
   # These are general development dependencies which are used in instrumentation
-  # tests. Specific versions are pulled in using specific gemfiles, e.g. 
+  # tests. Specific versions are pulled in using specific gemfiles, e.g.
   # `gems/rails3.gemfile`.
   s.add_development_dependency "activerecord"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Ruby 3.0.0 was [released today](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/), this updates the `required_ruby_version` to allow for this version.