### PR TITLE
Handle multiline psql sql sanitizing

### DIFF
--- a/lib/scout_apm/utils/sql_sanitizer_regex.rb
+++ b/lib/scout_apm/utils/sql_sanitizer_regex.rb
@@ -5,13 +5,13 @@ module ScoutApm
       MULTIPLE_SPACES    = %r|\s+|.freeze
       MULTIPLE_QUESTIONS = /\?(,\?)+/.freeze
 
-      PSQL_VAR_INTERPOLATION = %r|\[\[.*\]\]\s*$|.freeze
+      PSQL_VAR_INTERPOLATION = %r|\[\[.*\]\]\s*\z|.freeze
       PSQL_REMOVE_STRINGS = /'(?:[^']|'')*'/.freeze
       PSQL_REMOVE_INTEGERS = /(?<!LIMIT )\b\d+\b/.freeze
       PSQL_PLACEHOLDER = /\$\d+/.freeze
       PSQL_IN_CLAUSE = /IN\s+\(\?[^\)]*\)/.freeze
-      PSQL_AFTER_WHERE = /(?:WHERE\s+).*?(?:SELECT|$)/i.freeze
-      PSQL_AFTER_SET = /(?:SET\s+).*?(?:WHERE|$)/i.freeze
+      PSQL_AFTER_WHERE = /(?:WHERE\s+).*?(?:SELECT|\z)/im.freeze
+      PSQL_AFTER_SET = /(?:SET\s+).*?(?:WHERE|\z)/im.freeze
 
       MYSQL_VAR_INTERPOLATION = %r|\[\[.*\]\]\s*$|.freeze
       MYSQL_REMOVE_INTEGERS = /(?<!LIMIT )\b\d+\b/.freeze

--- a/test/unit/sql_sanitizer_test.rb
+++ b/test/unit/sql_sanitizer_test.rb
@@ -146,7 +146,7 @@ module ScoutApm
         assert_equal %q|UPDATE "mytable" SET "myfield" = ?, "countofthings" = ? WHERE "user_id" = ?|, ss.to_s
       end
 
-      def test_multiline_sql
+      def test_postgres_multiline_sql
         sql = %q|
         SELECT "html_form_payloads".*
         FROM "html_form_payloads"
@@ -162,6 +162,19 @@ module ScoutApm
 
         ss = SqlSanitizer.new(sql).tap{ |it| it.database_engine = :postgres }
         assert_equal %q|SELECT "html_form_payloads".* FROM "html_form_payloads" INNER JOIN "leads" ON "leads"."payload_id" = "html_form_payloads"."id" AND "leads"."payload_type" = ? WHERE html_form_payloads.id < ? AND "form_type" = ? AND (params::varchar = ?) AND (leads.url = ?) ORDER BY "html_form_payloads"."id" ASC LIMIT ?|, ss.to_s
+      end
+
+      def test_mysql_multiline
+        sql = %q|
+        SELECT `blogs`.*
+        FROM `blogs`
+        WHERE (title = 'abc')
+        |
+
+        ss = SqlSanitizer.new(sql).tap{ |it| it.database_engine = :mysql }
+        assert_equal %q|SELECT `blogs`.*
+        FROM `blogs`
+        WHERE (title = ?)|, ss.to_s
       end
 
       def assert_faster_than(target_seconds)

--- a/test/unit/sql_sanitizer_test.rb
+++ b/test/unit/sql_sanitizer_test.rb
@@ -146,6 +146,24 @@ module ScoutApm
         assert_equal %q|UPDATE "mytable" SET "myfield" = ?, "countofthings" = ? WHERE "user_id" = ?|, ss.to_s
       end
 
+      def test_multiline_sql
+        sql = %q|
+        SELECT "html_form_payloads".*
+        FROM "html_form_payloads"
+        INNER JOIN "leads" ON "leads"."payload_id" = "html_form_payloads"."id"
+               AND "leads"."payload_type" = ?
+        WHERE html_form_payloads.id < 10
+          AND "form_type" = 'xyz'
+          AND (params::varchar = '{"name":"Chris","resident":"Yes","e-content":"Secret content"}')
+          AND (leads.url = 'http://example.com')
+        ORDER BY "html_form_payloads"."id" ASC
+        LIMIT ?
+        |
+
+        ss = SqlSanitizer.new(sql).tap{ |it| it.database_engine = :postgres }
+        assert_equal %q|SELECT "html_form_payloads".* FROM "html_form_payloads" INNER JOIN "leads" ON "leads"."payload_id" = "html_form_payloads"."id" AND "leads"."payload_type" = ? WHERE html_form_payloads.id < ? AND "form_type" = ? AND (params::varchar = ?) AND (leads.url = ?) ORDER BY "html_form_payloads"."id" ASC LIMIT ?|, ss.to_s
+      end
+
       def assert_faster_than(target_seconds)
         t1 = ::Time.now
         yield


### PR DESCRIPTION
Multiline postgres sql was avoiding some of the sanitization we have. This is rare since AR doesn't create that kind of SQL itself normally. 

Also added a simple test for mysql sql as well.