### PR TITLE
Pass kwargs to render_partial instrument in TemplateRenderer (for locals)

### DIFF
--- a/lib/scout_apm/instruments/action_view.rb
+++ b/lib/scout_apm/instruments/action_view.rb
@@ -138,11 +138,7 @@ module ScoutApm
 
           begin
             req.start_layer(layer)
-            if ScoutApm::Agent.instance.context.environment.supports_kwarg_delegation?
-              super(*args, **kwargs)
-            else
-              super(*args)
-            end
+            super(*args, **kwargs)
           ensure
             req.stop_layer
           end


### PR DESCRIPTION


But don't do that in the PartialRenderer instrument, which has different interface that has locals as an instance var, not passed to the method. (Rails 6.0.3, Rails 4.2)