### PR TITLE
Removing Hack for Regexp supporting ruby 1.8.7

### DIFF
--- a/lib/scout_apm/serializers/payload_serializer_to_json.rb
+++ b/lib/scout_apm/serializers/payload_serializer_to_json.rb
@@ -45,31 +45,17 @@ module ScoutApm
           "{#{str_parts.join(",")}}"
         end
 
-        # Ruby 1.8.7 seems to be fundamentally different in how gsub or regexes
-        # work. This is a hack and will be removed as soon as we can drop
-        # support
-        if RUBY_VERSION == "1.8.7"
-          ESCAPE_MAPPINGS = {
-            "\b" => '\\b',
-            "\t" => '\\t',
-            "\n" => '\\n',
-            "\f" => '\\f',
-            "\r" => '\\r',
-            '"'  => '\\"',
-            '\\' => '\\\\',
-          }
-        else
-          ESCAPE_MAPPINGS = {
-            # Stackoverflow answer on gsub matches and backslashes - https://stackoverflow.com/a/4149087/2705125
-            '\\' => '\\\\\\\\',
-            "\b" => '\\b',
-            "\t" => '\\t',
-            "\n" => '\\n',
-            "\f" => '\\f',
-            "\r" => '\\r',
-            '"'  => '\\"',
-          }
-        end
+        ESCAPE_MAPPINGS = {
+          # Stackoverflow answer on gsub matches and backslashes
+          # https://stackoverflow.com/a/4149087/2705125
+          '\\' => '\\\\\\\\',
+          "\b" => '\\b',
+          "\t" => '\\t',
+          "\n" => '\\n',
+          "\f" => '\\f',
+          "\r" => '\\r',
+          '"'  => '\\"',
+        }
 
         def escape(string)
           ESCAPE_MAPPINGS.inject(string.to_s) {|s, (bad, good)| 


### PR DESCRIPTION
This hack, added on Oct 2020 (#360) was a way to fix a use case related to Regexp in ruby 1.8.7

Since Scout APM 4.0.0 (Nov 2020), the gem only support ruby ~> 2.1 (#270).

Is not longer possible to use ruby 1.8.7, the hack can be safely removed.

https://github.com/scoutapp/scout_apm_ruby/pull/360
https://github.com/scoutapp/scout_apm_ruby/pull/270