### PR TITLE
Set up desc on new layers before starting the layer

### DIFF
--- a/lib/scout_apm/instruments/typhoeus.rb
+++ b/lib/scout_apm/instruments/typhoeus.rb
@@ -29,10 +29,11 @@ module ScoutApm
 
       module TyphoeusHydraInstrumentation
         def run(*args, &block)
+          layer = ScoutApm::Layer.new("HTTP", "Hydra")
+          layer.desc = scout_desc if current_layer
+
           req = ScoutApm::RequestManager.lookup
-          req.start_layer(ScoutApm::Layer.new("HTTP", "Hydra"))
-          current_layer = req.current_layer
-          current_layer.desc = scout_desc if current_layer
+          req.start_layer(layer)
 
           begin
             super(*args, &block)
@@ -50,10 +51,11 @@ module ScoutApm
 
       module TyphoeusInstrumentation
         def run(*args, &block)
+          layer = ScoutApm::Layer.new("HTTP", scout_request_verb)
+          layer.desc = scout_desc(scout_request_verb, scout_request_url)
+
           req = ScoutApm::RequestManager.lookup
-          req.start_layer(ScoutApm::Layer.new("HTTP", scout_request_verb))
-          current_layer = req.current_layer
-          current_layer.desc = scout_desc(scout_request_verb, scout_request_url) if current_layer
+          req.start_layer(layer)
 
           begin
             super(*args, &block)


### PR DESCRIPTION
Set up desc on new layers before starting the layer rather than setting it on the current layer after start_layer.

To fix : https://github.com/scoutapp/scout_apm_ruby/issues/391

This means that if the current layer isn't the one we just tried to start then the desc isn't set on a layer we weren't expecting.

I haven't managed to reproduce this in a test (it's not clear to me the best way to test layering integration of different instrumentation).

Reproducing in a separate application was achieved by an active record callback calling Typhoeus (through elasticsearch) and then further active record operations taking place.