### PR TITLE
Improve blind delegation of ActiveRecordInstruments#log

### DIFF
--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -215,6 +215,7 @@ module ScoutApm
           end
         end
       end
+      ruby2_keywords :log if respond_to?(:ruby2_keywords, true)
     end
 
     module ActiveRecordInstruments
@@ -267,6 +268,7 @@ module ScoutApm
           end
         end
       end
+      ruby2_keywords :log if respond_to?(:ruby2_keywords, true)
     end
 
     ################################################################################


### PR DESCRIPTION
Should fix: https://github.com/scoutapp/scout_apm_ruby/issues/393

### Context

Rails edge changed the signature of `#log`, it now includes a keyword arg (see https://github.com/rails/rails/pull/40037)

The only proper way to blind delegate keyword args across versions is to use ruby2_keywords, see https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html for details.