### PR TITLE
prepend Net::HTTP instrumentation

### DIFF
--- a/lib/scout_apm/instruments/net_http.rb
+++ b/lib/scout_apm/instruments/net_http.rb
@@ -22,33 +22,31 @@ module ScoutApm
 
           logger.info "Instrumenting Net::HTTP"
 
-          ::Net::HTTP.class_eval do
-            include ScoutApm::Tracer
+          ::Net::HTTP.send(:include, ScoutApm::Tracer)
+          ::Net::HTTP.send(:prepend, NetHttpInstrumentation)
+        end
+      end
 
-            def request_with_scout_instruments(*args, &block)
-              self.class.instrument("HTTP", "request", :ignore_children => true, :desc => request_scout_description(args.first)) do
-                request_without_scout_instruments(*args, &block)
-              end
-            end
-
-            def request_scout_description(req)
-              path = req.path
-              path = path.path if path.respond_to?(:path)
-
-              # Protect against a nil address value
-              if @address.nil?
-                return "No Address Found"
-              end
-
-              max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
-              (@address + path.split('?').first)[0..(max_length - 1)]
-            rescue
-              ""
-            end
-
-            alias request_without_scout_instruments request
-            alias request request_with_scout_instruments
+      module NetHttpInstrumentation
+        def request(request, *args, &block)
+          self.class.instrument("HTTP", "request", :ignore_children => true, :desc => request_scout_description(args.first)) do
+            super(request, *args, &block)
           end
+        end
+
+        def request_scout_description(req)
+          path = req.path
+          path = path.path if path.respond_to?(:path)
+
+          # Protect against a nil address value
+          if @address.nil?
+            return "No Address Found"
+          end
+
+          max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+          (@address + path.split('?').first)[0..(max_length - 1)]
+        rescue
+          ""
         end
       end
     end


### PR DESCRIPTION
It gets `stack level too deep (SystemStackError)` with the latest airbrake, which uses `prepend` to hack `Net::HTTP` since 10.0.2.

To fix the SystemStackError, we should also use `prepend` to instrument `Net::HTTP`