### PR TITLE
Check that the parent layer exists, avoiding a race condition induced exception

### DIFF
--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -117,7 +117,12 @@ module ScoutApm
       # Must follow layer.record_stop_time! as the total_call_time is used to determine if the layer is significant.
       return if layer_insignificant?(layer)
 
-      @layers[-1].add_child(layer) if @layers.any?
+      # Check that the parent exists before calling a method on it, since some threading can get us into a weird state.
+      # this doesn't fix that state, but prevents exceptions from leaking out.
+      parent = @layers[-1]
+      if parent
+        parent.add_child(layer)
+      end
 
       # This must be called before checking if a backtrace should be collected as the call count influences our capture logic.
       # We call `#update_call_counts in stop layer to ensure the layer has a final desc. Layer#desc is updated during the AR instrumentation flow.


### PR DESCRIPTION
Rails live can apparently cause mismatches of layers, and close out parent layers before we get a chance to add their children.

This change makes sure we only fetch the parent layer once, instead of the previous one checking `@layers` twice.