### PR TITLE
Resolve Rails 6 depracation warning: ActiveRecord configs for env

### DIFF
--- a/lib/scout_apm/framework_integrations/rails_3_or_4.rb
+++ b/lib/scout_apm/framework_integrations/rails_3_or_4.rb
@@ -78,7 +78,7 @@ module ScoutApm
         end
 
         if adapter.nil?
-          adapter = ActiveRecord::Base.configurations[env]["adapter"]
+          adapter = ActiveRecord::Base.configurations.configs_for(env)["adapter"]
         end
 
         return adapter


### PR DESCRIPTION
calling `[]` for the configurations method is deprecated.
Check this out https://bigbinary.com/blog/rails-6-changed-activerecord-base-configurations-result-to-an-object