### PR TITLE
Do not crash the app if Scout can't log to a file

### DIFF
--- a/lib/scout_apm/logger.rb
+++ b/lib/scout_apm/logger.rb
@@ -69,7 +69,7 @@ module ScoutApm
     private
 
     def build_logger
-      logger_class.new(@log_destination)
+      logger_class.new(@log_destination) rescue logger_class.new
     end
 
     def logger_class


### PR DESCRIPTION
I have not tested this change, but just to open up the discussion. 

Maybe Scout should not block rails from booting if it cannot write to the default log folder.

Thanks

setting the ENV var `SCOUT_LOG_FILE_PATH` to `stdout` prevents this problem, but by default, it should not crash

```
passenger.log-[ 2021-09-03 02:14:38.5897 10450/7f6fc79a2700 Pool2/Implementation.cpp:287 ]: Could not spawn process for application /var/app/current: An error occured while starting up the preloader.
passenger.log-  Error ID: 997f79e2
passenger.log-  Error details saved to: /tmp/passenger-error-svSwzi.html
passenger.log:  Message from application: Permission denied @ rb_sysopen - /var/app/current/log/scout_apm.log (Errno::EACCES)
passenger.log-  /opt/rubies/ruby-2.6.8/lib/ruby/2.6.0/logger.rb:744:in `initialize'
passenger.log-  /opt/rubies/ruby-2.6.8/lib/ruby/2.6.0/logger.rb:744:in `open'
passenger.log-  /opt/rubies/ruby-2.6.8/lib/ruby/2.6.0/logger.rb:744:in `open_logfile'
passenger.log-  /opt/rubies/ruby-2.6.8/lib/ruby/2.6.0/logger.rb:736:in `set_dev'
passenger.log-  /opt/rubies/ruby-2.6.8/lib/ruby/2.6.0/logger.rb:671:in `initialize'
passenger.log-  /opt/rubies/ruby-2.6.8/lib/ruby/2.6.0/logger.rb:387:in `new'
passenger.log-  /opt/rubies/ruby-2.6.8/lib/ruby/2.6.0/logger.rb:387:in `initialize'
passenger.log:  /var/app/current/vendor/bundle/gems/scout_apm-4.1.2/lib/scout_apm/logger.rb:72:in `new'
passenger.log:  /var/app/current/vendor/bundle/gems/scout_apm-4.1.2/lib/scout_apm/logger.rb:72:in `build_logger'
```