### PR TITLE
Set dependency version to parser

### DIFF
--- a/scout_apm.gemspec
+++ b/scout_apm.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake-compiler"
   s.add_development_dependency "addressable"
   s.add_development_dependency "activesupport"
-  s.add_runtime_dependency "parser"
+  s.add_runtime_dependency "parser", ">= 2.5.0.0"
 
   # These are general development dependencies which are used in instrumentation
   # tests. Specific versions are pulled in using specific gemfiles, e.g. 


### PR DESCRIPTION
I found parser dependency. With parser < 2.5.0.0, app can't start.
I think parser's version should be specified and create PR.

This error is caused when app start.
```
/app/vendor/bundle/ruby/2.6.0/gems/scout_apm-4.1.2/lib/scout_apm/auto_instrument/parser.rb:3:in `<top (required)>': Parser::TreeRewriter was not defined (LoadError)
```

Parser::TreeRewriter was implemented in parser 2.5.0.0
- https://github.com/whitequark/parser/commit/b0a7695f25de1ff717d4e1c23f45e647ccbcdc54#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16