### PR TITLE
Add magic comment frozen_string_literal: false to files where strings are modified

### DIFF
--- a/lib/scout_apm/instant/middleware.rb
+++ b/lib/scout_apm/instant/middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module ScoutApm
   module Instant
 

--- a/lib/scout_apm/instruments/elasticsearch.rb
+++ b/lib/scout_apm/instruments/elasticsearch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module ScoutApm
   module Instruments
     class Elasticsearch

--- a/lib/scout_apm/instruments/sinatra.rb
+++ b/lib/scout_apm/instruments/sinatra.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 # XXX: Is this file used?
 module ScoutApm
   module Instruments

--- a/lib/scout_apm/utils/sql_sanitizer.rb
+++ b/lib/scout_apm/utils/sql_sanitizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'scout_apm/environment'
 
 # Removes actual values from SQL. Used to both obfuscate the SQL and group

--- a/test/unit/sql_sanitizer_test.rb
+++ b/test/unit/sql_sanitizer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'test_helper'
 
 module ScoutApm


### PR DESCRIPTION
I was running scout in an environment where strings are frozen by default (using `RUBYOPT="--enable=frozen-string-literal"`) and Scout started raising exceptions. 

The magic comments allow it to run in this environment, without affecting a "typical" setup, or changing code.  

Before this PR, running tests using `RUBYOPT="--enable=frozen-string-literal rake` on `scout_apm_ruby` fails. After, it passes. 