### PR TITLE
Call to_h on ActiveRecord::Base.configurations

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 * Specify correct (MIT) license in Gemspec (#430)
 * Install HTTP::Client instruments (#420)
 * Sanitize FROM jsonb_as_recordset AS correctly in Postgres (#332)
+* Call to_h on `ActiveRecord::Base.configurations` (#434)
 
 # 5.0.0
 

--- a/lib/scout_apm/framework_integrations/rails_3_or_4.rb
+++ b/lib/scout_apm/framework_integrations/rails_3_or_4.rb
@@ -78,7 +78,7 @@ module ScoutApm
         end
 
         if adapter.nil?
-          adapter = ActiveRecord::Base.configurations[env]["adapter"]
+          adapter = ActiveRecord::Base.configurations.to_h[env]["adapter"]
         end
 
         return adapter


### PR DESCRIPTION
Rails 6 updated the value of `ActiveRecord::Base.configurations` to return an object instead of a plain hash. See https://github.com/rails/rails/pull/33637 for more info.

To avoid deprecation warning when accessing the object using `[]`, we instead call `to_h` to get a plain hash like we expected before the Rails 6 change. The `to_h` call is the recommended way to get these configs in a backward compatible way.