### PR TITLE
Allow using `YAML.unsafe_load` when reading scout_apm.yml

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,7 @@
 * Install HTTP::Client instruments (#420)
 * Sanitize FROM jsonb_as_recordset AS correctly in Postgres (#332)
 * Call to_h on `ActiveRecord::Base.configurations` (#434)
+* Allow loading of trusted `config/scout_apm.yml` via `YAML.unsafe_load` if available (#435)
 
 # 5.0.0
 

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -432,7 +432,7 @@ module ScoutApm
         begin
           raw_file = File.read(@resolved_file_path)
           erb_file = ERB.new(raw_file).result(binding)
-          parsed_yaml = YAML.load(erb_file)
+          parsed_yaml = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(erb_file) : YAML.load(erb_file)
           file_settings = parsed_yaml[app_environment]
 
           if file_settings.is_a? Hash


### PR DESCRIPTION
Due to https://github.com/ruby/psych/pull/487 making YAML loads strict by default, when someone is running with Psych > 4 and Scout attempts to load `config/scout_apm.yml` with references, an exception is raised, caught, and logged, but the config is not loaded from the file.

Similar to the rails change https://github.com/rails/rails/pull/42257, we can consider configuration files as trusted.  This change reads the yml file with `unsafe_load` if available.