### PR TITLE
Initial commit for adding prepend in addition to alias_method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,13 @@ jobs:
           - ruby: 3.0
           - ruby: 3.0
             prepend: true
+          - ruby: 3.0
+            gemfile: gems/instruments.gemfile
+            test_features: "instruments"
+          - ruby: 3.0
+            gemfile: gems/instruments.gemfile
+            prepend: true
+            test_features: "instruments"
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,16 @@ jobs:
             gemfile: gems/rails3.gemfile
             bundler: 1.17.3
           - ruby: 2.7
+          - ruby: 2.7
+            prepend: true
           - ruby: 3.0
+          - ruby: 3.0
+            prepend: true
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       SCOUT_TEST_FEATURES: ${{ matrix.test_features }}
+      SCOUT_USE_PREPEND: ${{ matrix.prepend }}
 
     runs-on: ubuntu-latest
 

--- a/gems/instruments.gemfile
+++ b/gems/instruments.gemfile
@@ -1,0 +1,6 @@
+eval_gemfile("../Gemfile")
+
+gem 'httpclient'
+gem 'http'
+gem 'redis'
+gem 'moped'

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -199,7 +199,7 @@ module ScoutApm
       'auto_instruments' => BooleanCoercion.new,
       'auto_instruments_ignore' => JsonCoercion.new,
       'use_prepend' => BooleanCoercion.new,
-      'alias_method_instruments', JsonCoercion.new,
+      'alias_method_instruments' => JsonCoercion.new,
       'prepend_instruments' => JsonCoercion.new,
       'errors_enabled' => BooleanCoercion.new,
       'errors_ignored_exceptions' => JsonCoercion.new,

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -318,7 +318,7 @@ module ScoutApm
         'auto_instruments' => false,
         'auto_instruments_ignore' => [],
         'use_prepend' => false,
-        'alias_method_instruments', => [],
+        'alias_method_instruments' => [],
         'prepend_instruments' => [],
         'ssl_cert_file' => File.join( File.dirname(__FILE__), *%w[.. .. data cacert.pem] ),
         'errors_enabled' => false,

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -35,7 +35,13 @@ require 'scout_apm/environment'
 # start_resque_server_instrument - Used in special situations with certain Resque installs
 # timeline_traces - true/false to enable sending of of the timeline trace format.
 # auto_instruments - true/false whether to install autoinstruments. Only installed if on a supported Ruby version.
-# auto_instruments_ignore - An array of file names to exclude from autoinstruments (Ex: ['application_controller']).
+# auto_instruments_ignore  - An array of file names to exclude from autoinstruments (Ex: ['application_controller']).
+# use_prepend              - Whether to apply instrumentation using Module#Prepend instead
+#                            of Module#alias_method (Default: false)
+# alias_method_instruments - If `use_prepend` is true, continue to use Module#alias_method for
+#                            any instruments listed in this array. Default: []
+# prepend_instruments      - If `use_prepend` is false, force using Module#prepend for any
+#                            instruments listed in this array. Default: []
 #
 # Any of these config settings can be set with an environment variable prefixed
 # by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
@@ -85,6 +91,9 @@ module ScoutApm
         'timeline_traces',
         'auto_instruments',
         'auto_instruments_ignore',
+        'use_prepend',
+        'alias_method_instruments',
+        'prepend_instruments',
 
         # Error Service Related Configuration
         'errors_enabled',
@@ -189,6 +198,9 @@ module ScoutApm
       'timeline_traces' => BooleanCoercion.new,
       'auto_instruments' => BooleanCoercion.new,
       'auto_instruments_ignore' => JsonCoercion.new,
+      'use_prepend' => BooleanCoercion.new,
+      'alias_method_instruments', JsonCoercion.new,
+      'prepend_instruments' => JsonCoercion.new,
       'errors_enabled' => BooleanCoercion.new,
       'errors_ignored_exceptions' => JsonCoercion.new,
       'errors_filtered_params' => JsonCoercion.new,
@@ -305,6 +317,9 @@ module ScoutApm
         'timeline_traces' => true,
         'auto_instruments' => false,
         'auto_instruments_ignore' => [],
+        'use_prepend' => false,
+        'alias_method_instruments', => [],
+        'prepend_instruments' => [],
         'ssl_cert_file' => File.join( File.dirname(__FILE__), *%w[.. .. data cacert.pem] ),
         'errors_enabled' => false,
         'errors_ignored_exceptions' => %w(ActiveRecord::RecordNotFound ActionController::RoutingError),

--- a/lib/scout_apm/instrument_manager.rb
+++ b/lib/scout_apm/instrument_manager.rb
@@ -50,8 +50,6 @@ module ScoutApm
       (config.value("disabled_instruments") || []).include?(instrument_short_name)
     end
 
-    private
-
     def prepend_for_instrument?(instrument_klass)
       instrument_short_name = instrument_klass.name.split("::").last
 
@@ -59,15 +57,17 @@ module ScoutApm
       # If `use_prepend` is `true`, then we should default to using `prepend` unless
       # the instrument is explicitly listed in the `alias_method_instruments` config array.
       if config.value("use_prepend")
-        return (config.value("alias_method_instruments") || []).include?(instrument_short_name)
-      else
+        return false if (config.value("alias_method_instruments") || []).include?(instrument_short_name)
         return true
+      else
+        # `use_prepend` is false, but we should use `prepend` if the instrument is
+        # explicitly listed in the `prepend_instruments` array.
+        return true if (config.value("prepend_instruments") || []).include?(instrument_short_name)
+        return false
       end
-
-      # `use_prepend` is false, but we should use `prepend` if the instrument is
-      # explicitly listed in the `prepend_instruments` array.
-      return true if (config.value("prepend_instruments") || []).include?(instrument_short_name)
     end
+
+    private
 
     def install_instrument(instrument_klass)
       return if already_installed?(instrument_klass)

--- a/lib/scout_apm/instruments/action_controller_rails_2.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_2.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::ActionController) && defined?(::ActionController::Base)
           @installed = true
 

--- a/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
+++ b/lib/scout_apm/instruments/action_controller_rails_3_rails4.rb
@@ -21,7 +21,7 @@ module ScoutApm
         @installed = true
       end
 
-      def install
+      def install(prepend:)
         if !defined?(::ActiveSupport)
           return
         end

--- a/lib/scout_apm/instruments/action_view.rb
+++ b/lib/scout_apm/instruments/action_view.rb
@@ -29,7 +29,7 @@ module ScoutApm
         context.environment.supports_module_prepend?
       end
 
-      def install
+      def install(prepend:)
         return unless defined?(::ActionView) && defined?(::ActionView::PartialRenderer)
 
         if prependable?

--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -50,7 +50,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if install_via_after_initialize?
           Rails.configuration.after_initialize do
             add_instruments

--- a/lib/scout_apm/instruments/elasticsearch.rb
+++ b/lib/scout_apm/instruments/elasticsearch.rb
@@ -18,7 +18,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Elasticsearch) &&
             defined?(::Elasticsearch::Transport) &&
             defined?(::Elasticsearch::Transport::Client)

--- a/lib/scout_apm/instruments/elasticsearch.rb
+++ b/lib/scout_apm/instruments/elasticsearch.rb
@@ -25,7 +25,7 @@ module ScoutApm
 
           @installed = true
 
-          logger.info "Instrumenting Elasticsearch"
+          logger.info "Instrumenting Elasticsearch. Prepend: #{prepend}"
 
           if prepend
             ::Elasticsearch::Transport::Client.send(:include, ScoutApm::Tracer)

--- a/lib/scout_apm/instruments/grape.rb
+++ b/lib/scout_apm/instruments/grape.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Grape) && defined?(::Grape::Endpoint)
           @installed = true
 

--- a/lib/scout_apm/instruments/http.rb
+++ b/lib/scout_apm/instruments/http.rb
@@ -22,26 +22,46 @@ module ScoutApm
 
           logger.info "Instrumenting HTTP::Client"
 
-          ::HTTP::Client.class_eval do
-            include ScoutApm::Tracer
+          if prepend
+            ::HTTP::Client.send(:include, ScoutApm::Tracer)
+            ::HTTP::Client.send(:prepend, HTTPInstrumentationPrepend)
+          else
+            ::HTTP::Client.class_eval do
+              include ScoutApm::Tracer
 
-            def request_with_scout_instruments(verb, uri, opts = {})
-              self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
-                request_without_scout_instruments(verb, uri, opts)
+              def request_with_scout_instruments(verb, uri, opts = {})
+                self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
+                  request_without_scout_instruments(verb, uri, opts)
+                end
               end
-            end
 
-            def request_scout_description(verb, uri)
-              max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
-              (String(uri).split('?').first)[0..(max_length - 1)]
-            rescue
-              ""
-            end
+              def request_scout_description(verb, uri)
+                max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+                (String(uri).split('?').first)[0..(max_length - 1)]
+              rescue
+                ""
+              end
 
-            alias request_without_scout_instruments request
-            alias request request_with_scout_instruments
+              alias request_without_scout_instruments request
+              alias request request_with_scout_instruments
+            end
           end
         end
+      end
+    end
+
+    module HTTPInstrumentationPrepend
+      def request(verb, uri, opts = {})
+        self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
+          super(verb, uri, opts)
+        end
+      end
+
+      def request_scout_description(verb, uri)
+        max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+        (String(uri).split('?').first)[0..(max_length - 1)]
+      rescue
+        ""
       end
     end
   end

--- a/lib/scout_apm/instruments/http.rb
+++ b/lib/scout_apm/instruments/http.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::HTTP) && defined?(::HTTP::Client)
           @installed = true
 

--- a/lib/scout_apm/instruments/http.rb
+++ b/lib/scout_apm/instruments/http.rb
@@ -20,7 +20,7 @@ module ScoutApm
         if defined?(::HTTP) && defined?(::HTTP::Client)
           @installed = true
 
-          logger.info "Instrumenting HTTP::Client"
+          logger.info "Instrumenting HTTP::Client. Prepend: #{prepend}"
 
           if prepend
             ::HTTP::Client.send(:include, ScoutApm::Tracer)

--- a/lib/scout_apm/instruments/http_client.rb
+++ b/lib/scout_apm/instruments/http_client.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::HTTPClient)
           @installed = true
 

--- a/lib/scout_apm/instruments/http_client.rb
+++ b/lib/scout_apm/instruments/http_client.rb
@@ -20,11 +20,11 @@ module ScoutApm
         if defined?(::HTTPClient)
           @installed = true
 
-          logger.info "Instrumenting HTTPClient"
+          logger.info "Instrumenting HTTPClient. Prepend: #{prepend}"
 
           if prepend
             ::HTTPClient.send(:include, ScoutApm::Tracer)
-            ::HTTPClient.send(:prepend, HTTPClientInstrumentationPrepend)
+            ::HTTPClient.send(:prepend, HttpClientInstrumentationPrepend)
           else
             ::HTTPClient.class_eval do
               include ScoutApm::Tracer

--- a/lib/scout_apm/instruments/http_client.rb
+++ b/lib/scout_apm/instruments/http_client.rb
@@ -22,25 +22,44 @@ module ScoutApm
 
           logger.info "Instrumenting HTTPClient"
 
-          ::HTTPClient.class_eval do
-            include ScoutApm::Tracer
+          if prepend
+            ::HTTPClient.send(:include, ScoutApm::Tracer)
+            ::HTTPClient.send(:prepend, HTTPClientInstrumentationPrepend)
+          else
+            ::HTTPClient.class_eval do
+              include ScoutApm::Tracer
 
-            def request_with_scout_instruments(*args, &block)
+              def request_with_scout_instruments(*args, &block)
 
-              method = args[0].to_s
-              url = args[1]
+                method = args[0].to_s
+                url = args[1]
 
-              max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
-              url = url && url.to_s[0..(max_length - 1)]
+                max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+                url = url && url.to_s[0..(max_length - 1)]
 
-              self.class.instrument("HTTP", method, :desc => url) do
-                request_without_scout_instruments(*args, &block)
+                self.class.instrument("HTTP", method, :desc => url) do
+                  request_without_scout_instruments(*args, &block)
+                end
               end
-            end
 
-            alias request_without_scout_instruments request
-            alias request request_with_scout_instruments
+              alias request_without_scout_instruments request
+              alias request request_with_scout_instruments
+            end
           end
+        end
+      end
+    end
+
+    module HttpClientInstrumentationPrepend
+      def request(*args, &block)
+        method = args[0].to_s
+        url = args[1]
+
+        max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+        url = url && url.to_s[0..(max_length - 1)]
+
+        self.class.instrument("HTTP", method, :desc => url) do
+          super(request, *args, &block)
         end
       end
     end

--- a/lib/scout_apm/instruments/influxdb.rb
+++ b/lib/scout_apm/instruments/influxdb.rb
@@ -22,26 +22,45 @@ module ScoutApm
 
           logger.debug "Instrumenting InfluxDB"
 
-          ::InfluxDB::Client.class_eval do
-            include ScoutApm::Tracer
-          end
-
-          ::InfluxDB::HTTP.module_eval do
-            def do_request_with_scout_instruments(http, req, data = nil)
-              params = req.path[1..-1].split("?").last
-              cleaned_params = CGI.unescape(params).gsub(/(\s{2,})/,' ')
-
-              self.class.instrument("InfluxDB",
-                                    "#{req.path[1..-1].split("?").first.capitalize}",
-                                    :desc => cleaned_params,
-                                    :ignore_children => true) do
-                do_request_without_scout_instruments(http, req, data)
-              end
+          if prepend
+            ::InfluxDB::Client.send(:include, ScoutApm::Tracer)
+            ::InfluxDB::HTTP.send(:prepend, InfluxHttpInstrumentationPrepend)
+          else
+            ::InfluxDB::Client.class_eval do
+              include ScoutApm::Tracer
             end
 
-            alias_method :do_request_without_scout_instruments, :do_request
-            alias_method :do_request, :do_request_with_scout_instruments
+            ::InfluxDB::HTTP.module_eval do
+              def do_request_with_scout_instruments(http, req, data = nil)
+                params = req.path[1..-1].split("?").last
+                cleaned_params = CGI.unescape(params).gsub(/(\s{2,})/,' ')
+
+                self.class.instrument("InfluxDB",
+                                      "#{req.path[1..-1].split("?").first.capitalize}",
+                                      :desc => cleaned_params,
+                                      :ignore_children => true) do
+                  do_request_without_scout_instruments(http, req, data)
+                end
+              end
+
+              alias_method :do_request_without_scout_instruments, :do_request
+              alias_method :do_request, :do_request_with_scout_instruments
+            end
           end
+        end
+      end
+    end
+
+    module InfluxHttpInstrumentationPrepend
+      def do_request(http, req, data = nil)
+        params = req.path[1..-1].split("?").last
+        cleaned_params = CGI.unescape(params).gsub(/(\s{2,})/,' ')
+
+        self.class.instrument("InfluxDB",
+                              "#{req.path[1..-1].split("?").first.capitalize}",
+                              :desc => cleaned_params,
+                              :ignore_children => true) do
+          super(http, req, data)
         end
       end
     end

--- a/lib/scout_apm/instruments/influxdb.rb
+++ b/lib/scout_apm/instruments/influxdb.rb
@@ -20,47 +20,28 @@ module ScoutApm
         if defined?(::InfluxDB)
           @installed = true
 
-          logger.debug "Instrumenting InfluxDB"
+          logger.debug "Instrumenting InfluxDB. Prepend: #{prepend}"
 
-          if prepend
-            ::InfluxDB::Client.send(:include, ScoutApm::Tracer)
-            ::InfluxDB::HTTP.send(:prepend, InfluxHttpInstrumentationPrepend)
-          else
-            ::InfluxDB::Client.class_eval do
-              include ScoutApm::Tracer
-            end
-
-            ::InfluxDB::HTTP.module_eval do
-              def do_request_with_scout_instruments(http, req, data = nil)
-                params = req.path[1..-1].split("?").last
-                cleaned_params = CGI.unescape(params).gsub(/(\s{2,})/,' ')
-
-                self.class.instrument("InfluxDB",
-                                      "#{req.path[1..-1].split("?").first.capitalize}",
-                                      :desc => cleaned_params,
-                                      :ignore_children => true) do
-                  do_request_without_scout_instruments(http, req, data)
-                end
-              end
-
-              alias_method :do_request_without_scout_instruments, :do_request
-              alias_method :do_request, :do_request_with_scout_instruments
-            end
+          ::InfluxDB::Client.class_eval do
+            include ScoutApm::Tracer
           end
-        end
-      end
-    end
 
-    module InfluxHttpInstrumentationPrepend
-      def do_request(http, req, data = nil)
-        params = req.path[1..-1].split("?").last
-        cleaned_params = CGI.unescape(params).gsub(/(\s{2,})/,' ')
+          ::InfluxDB::HTTP.module_eval do
+            def do_request_with_scout_instruments(http, req, data = nil)
+              params = req.path[1..-1].split("?").last
+              cleaned_params = CGI.unescape(params).gsub(/(\s{2,})/,' ')
 
-        self.class.instrument("InfluxDB",
-                              "#{req.path[1..-1].split("?").first.capitalize}",
-                              :desc => cleaned_params,
-                              :ignore_children => true) do
-          super(http, req, data)
+              self.class.instrument("InfluxDB",
+                                    "#{req.path[1..-1].split("?").first.capitalize}",
+                                    :desc => cleaned_params,
+                                    :ignore_children => true) do
+                do_request_without_scout_instruments(http, req, data)
+              end
+            end
+
+            alias_method :do_request_without_scout_instruments, :do_request
+            alias_method :do_request, :do_request_with_scout_instruments
+          end
         end
       end
     end

--- a/lib/scout_apm/instruments/influxdb.rb
+++ b/lib/scout_apm/instruments/influxdb.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::InfluxDB)
           @installed = true
 

--- a/lib/scout_apm/instruments/influxdb.rb
+++ b/lib/scout_apm/instruments/influxdb.rb
@@ -20,7 +20,7 @@ module ScoutApm
         if defined?(::InfluxDB)
           @installed = true
 
-          logger.debug "Instrumenting InfluxDB. Prepend: #{prepend}"
+          logger.debug "Instrumenting InfluxDB."
 
           ::InfluxDB::Client.class_eval do
             include ScoutApm::Tracer

--- a/lib/scout_apm/instruments/memcached.rb
+++ b/lib/scout_apm/instruments/memcached.rb
@@ -20,11 +20,11 @@ module ScoutApm
         if defined?(::Dalli) && defined?(::Dalli::Client)
           @installed = true
 
-          logger.info "Instrumenting Memcached"
+          logger.info "Instrumenting Memcached. Prepend: #{prepend}"
 
           if prepend
             ::Dalli::Client.send(:include, ScoutApm::Tracer)
-            ::Dalli::Client.send(:prepend, RMemcachedInstrumentationPrepend)
+            ::Dalli::Client.send(:prepend, MemcachedInstrumentationPrepend)
           else
             ::Dalli::Client.class_eval do
               include ScoutApm::Tracer

--- a/lib/scout_apm/instruments/memcached.rb
+++ b/lib/scout_apm/instruments/memcached.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Dalli) && defined?(::Dalli::Client)
           @installed = true
 

--- a/lib/scout_apm/instruments/memcached.rb
+++ b/lib/scout_apm/instruments/memcached.rb
@@ -22,20 +22,35 @@ module ScoutApm
 
           logger.info "Instrumenting Memcached"
 
-          ::Dalli::Client.class_eval do
-            include ScoutApm::Tracer
+          if prepend
+            ::Dalli::Client.send(:include, ScoutApm::Tracer)
+            ::Dalli::Client.send(:prepend, RMemcachedInstrumentationPrepend)
+          else
+            ::Dalli::Client.class_eval do
+              include ScoutApm::Tracer
 
-            def perform_with_scout_instruments(*args, &block)
-              command = args.first rescue "Unknown"
+              def perform_with_scout_instruments(*args, &block)
+                command = args.first rescue "Unknown"
 
-              self.class.instrument("Memcached", command) do
-                perform_without_scout_instruments(*args, &block)
+                self.class.instrument("Memcached", command) do
+                  perform_without_scout_instruments(*args, &block)
+                end
               end
-            end
 
-            alias_method :perform_without_scout_instruments, :perform
-            alias_method :perform, :perform_with_scout_instruments
+              alias_method :perform_without_scout_instruments, :perform
+              alias_method :perform, :perform_with_scout_instruments
+            end
           end
+        end
+      end
+    end
+
+    module MemcachedInstrumentationPrepend
+      def perform(*args, &block)
+        command = args.first rescue "Unknown"
+
+        self.class.instrument("Memcached", command) do
+          super(*args, &block)
         end
       end
     end

--- a/lib/scout_apm/instruments/middleware_detailed.rb
+++ b/lib/scout_apm/instruments/middleware_detailed.rb
@@ -24,7 +24,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(ActionDispatch) && defined?(ActionDispatch::MiddlewareStack) && defined?(ActionDispatch::MiddlewareStack::Middleware)
           @installed = true
 

--- a/lib/scout_apm/instruments/middleware_summary.rb
+++ b/lib/scout_apm/instruments/middleware_summary.rb
@@ -21,7 +21,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(ActionDispatch) && defined?(ActionDispatch::MiddlewareStack)
           @installed = true
 

--- a/lib/scout_apm/instruments/mongoid.rb
+++ b/lib/scout_apm/instruments/mongoid.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         @installed = true
 
         # Mongoid versions that use Moped should instrument Moped.

--- a/lib/scout_apm/instruments/moped.rb
+++ b/lib/scout_apm/instruments/moped.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Moped)
           @installed = true
 

--- a/lib/scout_apm/instruments/moped.rb
+++ b/lib/scout_apm/instruments/moped.rb
@@ -20,7 +20,7 @@ module ScoutApm
         if defined?(::Moped)
           @installed = true
 
-          logger.info "Instrumenting Moped"
+          logger.info "Instrumenting Moped. Prepend: #{prepend}"
 
           if prepend
             ::Moped::Node.send(:include, ScoutApm::Tracer)

--- a/lib/scout_apm/instruments/moped.rb
+++ b/lib/scout_apm/instruments/moped.rb
@@ -22,32 +22,57 @@ module ScoutApm
 
           logger.info "Instrumenting Moped"
 
-          ::Moped::Node.class_eval do
-            include ScoutApm::Tracer
+          if prepend
+            ::Moped::Node.send(:include, ScoutApm::Tracer)
+            ::Moped::Node.send(:prepend, MopedInstrumentationPrepend)
+          else
+            ::Moped::Node.class_eval do
+              include ScoutApm::Tracer
 
-            def process_with_scout_instruments(operation, &callback)
-              if operation.respond_to?(:collection)
-                collection = operation.collection
-                name = "Process/#{collection}/#{operation.class.to_s.split('::').last}"
-                self.class.instrument("MongoDB", name, :annotate_layer => { :query => scout_sanitize_log(operation.log_inspect) }) do
-                  process_without_scout_instruments(operation, &callback)
+              def process_with_scout_instruments(operation, &callback)
+                if operation.respond_to?(:collection)
+                  collection = operation.collection
+                  name = "Process/#{collection}/#{operation.class.to_s.split('::').last}"
+                  self.class.instrument("MongoDB", name, :annotate_layer => { :query => scout_sanitize_log(operation.log_inspect) }) do
+                    process_without_scout_instruments(operation, &callback)
+                  end
                 end
               end
-            end
-            alias_method :process_without_scout_instruments, :process
-            alias_method :process, :process_with_scout_instruments
+              alias_method :process_without_scout_instruments, :process
+              alias_method :process, :process_with_scout_instruments
 
-            # replaces values w/ ?
-            def scout_sanitize_log(log)
-              return nil if log.length > 1000 # safeguard - don't sanitize large SQL statements
-              log.gsub(/(=>")((?:[^"]|"")*)"/) do
-                $1 + '?' + '"'
+              # replaces values w/ ?
+              def scout_sanitize_log(log)
+                return nil if log.length > 1000 # safeguard - don't sanitize large SQL statements
+                log.gsub(/(=>")((?:[^"]|"")*)"/) do
+                  $1 + '?' + '"'
+                end
               end
             end
           end
         end
       end
 
+    end
+
+    module MopedInstrumentationPrepend
+      def process(operation, &callback)
+        if operation.respond_to?(:collection)
+          collection = operation.collection
+          name = "Process/#{collection}/#{operation.class.to_s.split('::').last}"
+          self.class.instrument("MongoDB", name, :annotate_layer => { :query => scout_sanitize_log(operation.log_inspect) }) do
+            super(operation, &callback)
+          end
+        end
+      end
+
+      # replaces values w/ ?
+      def scout_sanitize_log(log)
+        return nil if log.length > 1000 # safeguard - don't sanitize large SQL statements
+        log.gsub(/(=>")((?:[^"]|"")*)"/) do
+          $1 + '?' + '"'
+        end
+      end
     end
   end
 end

--- a/lib/scout_apm/instruments/net_http.rb
+++ b/lib/scout_apm/instruments/net_http.rb
@@ -16,40 +16,68 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Net) && defined?(::Net::HTTP)
           @installed = true
 
-          logger.info "Instrumenting Net::HTTP"
+          logger.info "Instrumenting Net::HTTP. Prepend: #{prepend}"
 
-          ::Net::HTTP.class_eval do
-            include ScoutApm::Tracer
+          if prepend
+            ::Net::HTTP.send(:include, ScoutApm::Tracer)
+            ::Net::HTTP.send(:prepend, NetHttpInstrumentationPrepend)
+          else
+            ::Net::HTTP.class_eval do
+              include ScoutApm::Tracer
 
-            def request_with_scout_instruments(*args, &block)
-              self.class.instrument("HTTP", "request", :ignore_children => true, :desc => request_scout_description(args.first)) do
-                request_without_scout_instruments(*args, &block)
-              end
-            end
-
-            def request_scout_description(req)
-              path = req.path
-              path = path.path if path.respond_to?(:path)
-
-              # Protect against a nil address value
-              if @address.nil?
-                return "No Address Found"
+              def request_with_scout_instruments(*args, &block)
+                self.class.instrument("HTTP", "request", :ignore_children => true, :desc => request_scout_description(args.first)) do
+                  request_without_scout_instruments(*args, &block)
+                end
               end
 
-              max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
-              (@address + path.split('?').first)[0..(max_length - 1)]
-            rescue
-              ""
-            end
+              def request_scout_description(req)
+                path = req.path
+                path = path.path if path.respond_to?(:path)
 
-            alias request_without_scout_instruments request
-            alias request request_with_scout_instruments
+                # Protect against a nil address value
+                if @address.nil?
+                  return "No Address Found"
+                end
+
+                max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+                (@address + path.split('?').first)[0..(max_length - 1)]
+              rescue
+                ""
+              end
+
+              alias request_without_scout_instruments request
+              alias request request_with_scout_instruments
+            end
           end
         end
+      end
+    end
+
+    module NetHttpInstrumentationPrepend
+      def request(request, *args, &block)
+        self.class.instrument("HTTP", "request", :ignore_children => true, :desc => request_scout_description(args.first)) do
+          super(request, *args, &block)
+        end
+      end
+
+      def request_scout_description(req)
+        path = req.path
+        path = path.path if path.respond_to?(:path)
+
+        # Protect against a nil address value
+        if @address.nil?
+          return "No Address Found"
+        end
+
+        max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+        (@address + path.split('?').first)[0..(max_length - 1)]
+      rescue
+        ""
       end
     end
   end

--- a/lib/scout_apm/instruments/rails_router.rb
+++ b/lib/scout_apm/instruments/rails_router.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(ActionDispatch) && defined?(ActionDispatch::Routing) && defined?(ActionDispatch::Routing::RouteSet)
           @installed = true
 

--- a/lib/scout_apm/instruments/redis.rb
+++ b/lib/scout_apm/instruments/redis.rb
@@ -22,20 +22,35 @@ module ScoutApm
 
           logger.info "Instrumenting Redis"
 
-          ::Redis::Client.class_eval do
-            include ScoutApm::Tracer
+          if prepend
+            ::Redis::Client.send(:include, ScoutApm::Tracer)
+            ::Redis::Client.send(:prepend, RedisClientInstrumentationPrepend)
+          else
+            ::Redis::Client.class_eval do
+              include ScoutApm::Tracer
 
-            def call_with_scout_instruments(*args, &block)
-              command = args.first.first rescue "Unknown"
+              def call_with_scout_instruments(*args, &block)
+                command = args.first.first rescue "Unknown"
 
-              self.class.instrument("Redis", command) do
-                call_without_scout_instruments(*args, &block)
+                self.class.instrument("Redis", command) do
+                  call_without_scout_instruments(*args, &block)
+                end
               end
-            end
 
-            alias_method :call_without_scout_instruments, :call
-            alias_method :call, :call_with_scout_instruments
+              alias_method :call_without_scout_instruments, :call
+              alias_method :call, :call_with_scout_instruments
+            end
           end
+        end
+      end
+    end
+
+    module RedisClientInstrumentationPrepend
+      def call(*args, &block)
+        command = args.first.first rescue "Unknown"
+
+        self.class.instrument("Redis", command) do
+          super(*args, &block)
         end
       end
     end

--- a/lib/scout_apm/instruments/redis.rb
+++ b/lib/scout_apm/instruments/redis.rb
@@ -20,7 +20,7 @@ module ScoutApm
         if defined?(::Redis) && defined?(::Redis::Client)
           @installed = true
 
-          logger.info "Instrumenting Redis"
+          logger.info "Instrumenting Redis. Prepend: #{prepend}"
 
           if prepend
             ::Redis::Client.send(:include, ScoutApm::Tracer)

--- a/lib/scout_apm/instruments/redis.rb
+++ b/lib/scout_apm/instruments/redis.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Redis) && defined?(::Redis::Client)
           @installed = true
 

--- a/lib/scout_apm/instruments/sinatra.rb
+++ b/lib/scout_apm/instruments/sinatra.rb
@@ -15,7 +15,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Sinatra) && defined?(::Sinatra::Base) && ::Sinatra::Base.private_method_defined?(:dispatch!)
           @installed = true
 

--- a/lib/scout_apm/instruments/typhoeus.rb
+++ b/lib/scout_apm/instruments/typhoeus.rb
@@ -16,7 +16,7 @@ module ScoutApm
         @installed
       end
 
-      def install
+      def install(prepend:)
         if defined?(::Typhoeus)
           @installed = true
 

--- a/test/unit/instruments/active_record_test.rb
+++ b/test/unit/instruments/active_record_test.rb
@@ -29,7 +29,7 @@ class ActiveRecordTest < Minitest::Test
     agent_context.recorder = recorder
 
     instrument = ScoutApm::Instruments::ActiveRecord.new(agent_context)
-    instrument.install
+    instrument.install(prepend: false)
 
     ScoutApm::Tracer.instrument("Controller", "foo/bar") do
       user = User.create

--- a/test/unit/instruments/http_client_test.rb
+++ b/test/unit/instruments/http_client_test.rb
@@ -1,0 +1,24 @@
+if (ENV["SCOUT_TEST_FEATURES"] || "").include?("instruments")
+  require 'test_helper'
+
+  require 'scout_apm/instruments/http_client'
+
+  require 'httpclient'
+
+  class HttpClientTest < Minitest::Test
+    def setup
+      @context = ScoutApm::AgentContext.new
+      @instance = ScoutApm::Instruments::HttpClient.new(@context)
+      @instrument_manager = ScoutApm::InstrumentManager.new(@context)
+      @instance.install(prepend: @instrument_manager.prepend_for_instrument?(@instance.class))
+    end
+
+    def test_installs_using_proper_method
+      if @instrument_manager.prepend_for_instrument?(@instance.class) == true
+        assert ::HTTPClient.ancestors.include?(ScoutApm::Instruments::HttpClientInstrumentationPrepend)
+      else
+        assert_equal false, ::HTTPClient.ancestors.include?(ScoutApm::Instruments::HttpClientInstrumentationPrepend)
+      end
+    end
+  end
+end

--- a/test/unit/instruments/http_test.rb
+++ b/test/unit/instruments/http_test.rb
@@ -1,0 +1,24 @@
+if (ENV["SCOUT_TEST_FEATURES"] || "").include?("instruments")
+  require 'test_helper'
+
+  require 'scout_apm/instruments/http'
+
+  require 'http'
+
+  class HttpTest < Minitest::Test
+    def setup
+      @context = ScoutApm::AgentContext.new
+      @instance = ScoutApm::Instruments::HTTP.new(@context)
+      @instrument_manager = ScoutApm::InstrumentManager.new(@context)
+      @instance.install(prepend: @instrument_manager.prepend_for_instrument?(@instance.class))
+    end
+
+    def test_installs_using_proper_method
+      if @instrument_manager.prepend_for_instrument?(@instance.class) == true
+        assert ::HTTP::Client.ancestors.include?(ScoutApm::Instruments::HTTPInstrumentationPrepend)
+      else
+        assert_equal false, ::HTTP::Client.ancestors.include?(ScoutApm::Instruments::HTTPInstrumentationPrepend)
+      end
+    end
+  end
+end

--- a/test/unit/instruments/moped_test.rb
+++ b/test/unit/instruments/moped_test.rb
@@ -1,0 +1,24 @@
+if (ENV["SCOUT_TEST_FEATURES"] || "").include?("instruments")
+  require 'test_helper'
+
+  require 'scout_apm/instruments/moped'
+
+  require 'moped'
+
+  class MopedTest < Minitest::Test
+    def setup
+      @context = ScoutApm::AgentContext.new
+      @instance = ScoutApm::Instruments::Moped.new(@context)
+      @instrument_manager = ScoutApm::InstrumentManager.new(@context)
+      @instance.install(prepend: @instrument_manager.prepend_for_instrument?(@instance.class))
+    end
+
+    def test_installs_using_proper_method
+      if @instrument_manager.prepend_for_instrument?(@instance.class) == true
+        assert ::Moped::Node.ancestors.include?(ScoutApm::Instruments::MopedInstrumentationPrepend)
+      else
+        assert_equal false, ::Moped::Node.ancestors.include?(ScoutApm::Instruments::MopedInstrumentationPrepend)
+      end
+    end
+  end
+end

--- a/test/unit/instruments/net_http_test.rb
+++ b/test/unit/instruments/net_http_test.rb
@@ -7,7 +7,9 @@ require 'addressable/uri'
 class NetHttpTest < Minitest::Test
   def setup
     @context = ScoutApm::AgentContext.new
-    ScoutApm::Instruments::NetHttp.new(@context).install
+    @instance = ScoutApm::Instruments::NetHttp.new(@context)
+    @instrument_manager = ScoutApm::InstrumentManager.new(@context)
+    @instance.install(prepend: @instrument_manager.prepend_for_instrument?(@instance.class))
   end
 
   def test_request_scout_description_for_uri
@@ -23,5 +25,13 @@ class NetHttpTest < Minitest::Test
   def test_request_scout_description_for_addressable
     req = Net::HTTP::Get.new(Addressable::URI.parse('http://example.org/here'))
     assert_equal '/here', Net::HTTP.new('').request_scout_description(req)
+  end
+
+  def test_installs_using_proper_method
+    if @instrument_manager.prepend_for_instrument?(@instance.class) == true
+      assert Net::HTTP.ancestors.include?(ScoutApm::Instruments::NetHttpInstrumentationPrepend)
+    else
+      assert_equal false, Net::HTTP.ancestors.include?(ScoutApm::Instruments::NetHttpInstrumentationPrepend)
+    end
   end
 end

--- a/test/unit/instruments/redis_test.rb
+++ b/test/unit/instruments/redis_test.rb
@@ -1,0 +1,24 @@
+if (ENV["SCOUT_TEST_FEATURES"] || "").include?("instruments")
+  require 'test_helper'
+
+  require 'scout_apm/instruments/redis'
+
+  require 'redis'
+
+  class RedisTest < Minitest::Test
+    def setup
+      @context = ScoutApm::AgentContext.new
+      @instance = ScoutApm::Instruments::Redis.new(@context)
+      @instrument_manager = ScoutApm::InstrumentManager.new(@context)
+      @instance.install(prepend: @instrument_manager.prepend_for_instrument?(@instance.class))
+    end
+
+    def test_installs_using_proper_method
+      if @instrument_manager.prepend_for_instrument?(@instance.class) == true
+        assert ::Redis::Client.ancestors.include?(ScoutApm::Instruments::RedisClientInstrumentationPrepend)
+      else
+        assert_equal false, ::Redis::Client.ancestors.include?(ScoutApm::Instruments::RedisClientInstrumentationPrepend)
+      end
+    end
+  end
+end

--- a/test/unit/instruments/typhoeus_test.rb
+++ b/test/unit/instruments/typhoeus_test.rb
@@ -10,7 +10,7 @@ if (ENV["SCOUT_TEST_FEATURES"] || "").include?("typhoeus")
       @context = ScoutApm::AgentContext.new
       @recorder = FakeRecorder.new
       ScoutApm::Agent.instance.context.recorder = @recorder
-      ScoutApm::Instruments::Typhoeus.new(@context).install
+      ScoutApm::Instruments::Typhoeus.new(@context).install(prepend: false)
     end
 
     def test_instruments_typhoeus_hydra


### PR DESCRIPTION
For many of our instruments, we still use `Module#alias_method` to monkeypatch specific methods to gather telemetry. The more modern approach is to use `Module#prepend`, which many other gems now use as default.

Moving from `alias_method` to `prepend` has caused major headaches for nearly all gems which made the switch, despite making the change in a major version semantic version bump. In order to allow a less disruptive upgrade path, Scout will continue to use `alias_method` as the default, but with available configuration option to move either all instrumentation to `prepend`, or selectively move instrumentation to `prepend`.

We will consider making the `prepend` instrumentation default after this configurable option has been released for a sufficient amount of time.

This is the initial draft PR starting with the NetHTTP instrumentation (there's still some duplicate instrumentation code for NetHTTP). We'll need to do the same for all of the other instruments.

Resolves https://github.com/scoutapp/scout_apm_ruby/issues/404
Resolves https://github.com/scoutapp/scout_apm_ruby/issues/309
Resolves https://github.com/scoutapp/scout_apm_ruby/issues/114

Replaces PR https://github.com/scoutapp/scout_apm_ruby/pull/402