### PR TITLE
Fix typo in "request" method of HTTP::Client

### DIFF
--- a/lib/scout_apm/instruments/http_client.rb
+++ b/lib/scout_apm/instruments/http_client.rb
@@ -59,7 +59,7 @@ module ScoutApm
         url = url && url.to_s[0..(max_length - 1)]
 
         self.class.instrument("HTTP", method, :desc => url) do
-          super(request, *args, &block)
+          super(*args, &block)
         end
       end
     end


### PR DESCRIPTION
looks like a typo for me

without this fix:
```ruby
> require 'scout_apm'; require 'scout_instruments'; HTTPClient.new.request(:get, 'http://e1.ru/')

Traceback (most recent call last):
       16: from /usr/lib/ruby/2.7.0/set.rb:328:in `each'
       15: from /usr/lib/ruby/2.7.0/set.rb:328:in `each_key'
       14: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:67:in `block (2 levels) in each'
       13: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_converters/depth_first_walker.rb:36:in `block in walk'
       12: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_converters/depth_first_walker.rb:33:in `walk'
       11: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:65:in `each'
       10: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:65:in `each'
        9: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:66:in `block in each'
        8: from /usr/lib/ruby/2.7.0/set.rb:328:in `each'
        7: from /usr/lib/ruby/2.7.0/set.rb:328:in `each_key'
        6: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:67:in `block (2 levels) in each'
        5: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_converters/depth_first_walker.rb:36:in `block in walk'
        4: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_converters/depth_first_walker.rb:33:in `walk'
        3: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:65:in `each'
        2: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:65:in `each'
        1: from /bundle/2.7-deb/ruby/2.7.0/gems/scout_apm-5.3.0/lib/scout_apm/layer_children_set.rb:66:in `block in each'
SystemStackError (stack level too deep)
```

after fix:
```ruby
> require 'scout_apm'; require 'scout_instruments'; HTTPClient.new.request(:get, 'http://e1.ru/')

=> #<HTTP::Message:0x0000562ffc01efa0 @http_header=#...
```

no test coverage for this line
