### PR TITLE
Work around Puma config option duplication causing before_worker_boot to double-fire

### DIFF
--- a/lib/scout_apm/server_integrations/puma.rb
+++ b/lib/scout_apm/server_integrations/puma.rb
@@ -24,7 +24,7 @@ module ScoutApm
       end
 
       def install
-        old = ::Puma.cli_config.options[:before_worker_boot] || []
+        old = ::Puma.cli_config.user_options[:before_worker_boot] || []
         new = Array(old) + [Proc.new do
           logger.info "Installing Puma worker loop."
           ScoutApm::Agent.instance.start_background_worker


### PR DESCRIPTION
Unfortunately Puma's implementation of configuration options does not symmetrically handle `[]` and `[]=`:

    def [](key)
      fetch(key)
    end

    def []=(key, value)
      user_options[key] = value
    end

    def fetch(key, default_value = nil)
      return user_options[key]    if user_options.key?(key)
      return file_options[key]    if file_options.key?(key)
      return default_options[key] if default_options.key?(key)

      default_value
    end

If there is a `before_worker_boot` on `file_options` or `default_options`, it will be returned when consulting `options[:before_worker_boot]`. Scout then appends to this array and sets it, intending to replace the existing array. But because `[]=` only sets `user_options` internally in `Puma::UserFileDefaultOptions`, we end up effectively with duplicated `before_worker_boot` handlers.

This works around this by directly looking up `user_options`, which will ensure parity between getting and setting after appending.