### PR TITLE
Work around Puma config option issue causing duplicate before_worker_boot invocations when scout_apm is loaded

### DIFF
--- a/lib/scout_apm/server_integrations/puma.rb
+++ b/lib/scout_apm/server_integrations/puma.rb
@@ -23,8 +23,36 @@ module ScoutApm
         defined?(::Puma) && (File.basename($0) =~ /\Apuma/)
       end
 
+      # Puma::UserFileDefaultOptions exposes `options` based on three underlying
+      # hashes: user_options, file_options, and default_options. While getting an `options`
+      # key consults all three underlying hashes, setting an `options` key only sets the
+      # user_options hash:
+      #
+      #    def [](key)
+      #      fetch(key)
+      #    end
+      #
+      #    def []=(key, value)
+      #      user_options[key] = value
+      #    end
+      #
+      #    def fetch(key, default_value = nil)
+      #      return user_options[key]    if user_options.key?(key)
+      #      return file_options[key]    if file_options.key?(key)
+      #      return default_options[key] if default_options.key?(key)
+      #
+      #      default_value
+      #    end
+      #
+      # Because of this, we can't read options[:before_worker_boot], modify, and then re-set
+      # options[:before_worker_boot], since doing so could cause duplication if `before_worker_boot`
+      # exists on the other two underlying hashes (file_options, default_options).
+      #
+      # To get around this, we explicitly read from `user_options` only, and still set using `options[]=`,
+      # which Puma allows for setting `user_options`.
+      #
       def install
-        old = ::Puma.cli_config.options[:before_worker_boot] || []
+        old = ::Puma.cli_config.options.user_options[:before_worker_boot] || []
         new = Array(old) + [Proc.new do
           logger.info "Installing Puma worker loop."
           ScoutApm::Agent.instance.start_background_worker


### PR DESCRIPTION
## Introduction

This fixes issue #253, which describes a bug causing Puma `on_worker_boot` callbacks to fire *twice* per definition when the `scout_apm` gem is included in the same Rails application. We discovered this issue (and then stumbled upon issue #253) while trying to add some statistics logging in our own Puma plugin, via a tread spawned in `on_worker_boot`. We were able to diagnose this as being an issue specifically with the `on_worker_boot` *callbacks* being fired twice (they were not *defined* or loaded twice), and it occurs only when `scout_apm` is included in the application and active via `monitor: true` in `config/scout_apm.yml`.

## Replication

This can be replicated by including both `puma` and `scout_apm` in a Rails application, setting `monitor: true` for your environment in `config/scout_apm.yml`, and then within `config/puma.rb` configuring two workers (since `on_worker_boot` is only invoked in multiple worker mode) as well as an `on_worker_boot` callback that logs a string:

```ruby
workers 2

on_worker_boot do
  puts "Invoked on_worker_boot"
end
```

This will result in the string "Invoked on_worker_boot" being logged *twice per worker*. If you remove `gem "scout_apm"` from the Gemfile, it will correctly be logged once per worker.

## The Issue

The underlying issue is a fairly nuanced interaction issue between how `scout_apm` hooks into Puma via `ScoutApm::ServerIntegrations::Puma#install` and how Puma handles getting and setting configuration options (which `scout_apm` uses via `::Puma.cli_config.options`).

Although the Scout integration appears to be straightforwardly grabbing an existing `before_worker_boot` value from `options`, appending to it, and re-setting the same key, Puma's implementation of configuration options (in `Puma::UserFileDefaultOptions`) unfortunately does not symmetrically handle `[]` and `[]=`:

```ruby
def [](key)
  fetch(key)
end

def []=(key, value)
  user_options[key] = value
end

def fetch(key, default_value = nil)
  return user_options[key]    if user_options.key?(key)
  return file_options[key]    if file_options.key?(key)
  return default_options[key] if default_options.key?(key)

  default_value
end
```

Note how setting will always set `user_options`, but getting is consulting three different underlying hashes in sequence. So if there is a `before_worker_boot` on `file_options` or `default_options`, it will be returned when consulting `options[:before_worker_boot]`. Scout then ppends to this array and sets it, intending to replace the existing array. But because `[]=` only sets `user_options` internally in `Puma::UserFileDefaultOptions`, we end up effectively with duplicated `before_worker_boot` handlers because of how scout interprets options in `run_hooks` and `all_of`:

```ruby
def run_hooks(key, arg, log_writer, hook_data = nil)
  @options.all_of(key).each do |b|
    ...
end

def all_of(key)
  user    = user_options[key]
  file    = file_options[key]
  default = default_options[key]

  user    = [user]    unless user.is_a?(Array)
  file    = [file]    unless file.is_a?(Array)
  default = [default] unless default.is_a?(Array)

  user.compact!
  file.compact!
  default.compact!

  user + file + default
end
```

## The Fix

This PR works around this issue by directly looking up `user_options`, which will ensure parity between getting and setting after appending. Because this is highly non-obvious unless you consult the Puma implementation of `options`, I've added an explanatory comment to the `install` method.

## Puma Plugin Implementation

If it's at all possible to do, it's probably more ideal for Scout to hook into Puma via a [puma plugin](https://github.com/puma/puma/blob/master/docs/plugins.md), which will avoid some of the awkwardness of manually fetching and re-setting existing options (that in part gave rise to this issue). That's out of scope for this PR, which is intent on working around the underlying issue described in original issue #253.

