### PR TITLE
Fix: call `add_instruments` after rails initialization when rails version is >= 3

### DIFF
--- a/lib/scout_apm/instruments/active_record.rb
+++ b/lib/scout_apm/instruments/active_record.rb
@@ -66,7 +66,7 @@ module ScoutApm
         defined?(::Rails) &&
           defined?(::Rails::VERSION) &&
           defined?(::Rails::VERSION::MAJOR) &&
-          ::Rails::VERSION::MAJOR.to_i == 3 &&
+          ::Rails::VERSION::MAJOR.to_i >= 3 &&
           ::Rails.respond_to?(:configuration)
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,6 +65,32 @@ class FakeEnvironment
   end
 end
 
+def fake_rails(version)
+  Kernel.const_set("Rails", Module.new)
+  Kernel.const_set("ActionController", Module.new)
+  r = Kernel.const_get("Rails")
+  r.const_set("VERSION", Module.new)
+  v = r.const_get("VERSION")
+  v.const_set("MAJOR", version)
+
+  assert_equal version, Rails::VERSION::MAJOR
+end
+
+def clean_fake_rails
+  Kernel.send(:remove_const, "Rails") if defined?(Kernel::Rails)
+  Kernel.send(:remove_const, "ActionController") if defined?(Kernel::ActionController)
+end
+
+def fake_sinatra
+  Kernel.const_set("Sinatra", Module.new)
+  s = Kernel.const_get("Sinatra")
+  s.const_set("Base", Module.new)
+end
+
+def clean_fake_sinatra
+  Kernel.const_unset("Sinatra") if defined?(Kernel::Sinatra)
+end
+
 # Helpers available to all tests
 class Minitest::Test
   def setup

--- a/test/unit/environment_test.rb
+++ b/test/unit/environment_test.rb
@@ -29,32 +29,4 @@ class EnvironmentTest < Minitest::Test
   def test_framework_ruby
     assert_equal :ruby, ScoutApm::Environment.send(:new).framework
   end
-
-  ############################################################
-
-  def fake_rails(version)
-    Kernel.const_set("Rails", Module.new)
-    Kernel.const_set("ActionController", Module.new)
-    r = Kernel.const_get("Rails")
-    r.const_set("VERSION", Module.new)
-    v = r.const_get("VERSION")
-    v.const_set("MAJOR", version)
-
-    assert_equal version, Rails::VERSION::MAJOR
-  end
-
-  def clean_fake_rails
-    Kernel.send(:remove_const, "Rails") if defined?(Kernel::Rails)
-    Kernel.send(:remove_const, "ActionController") if defined?(Kernel::ActionController)
-  end
-
-  def fake_sinatra
-    Kernel.const_set("Sinatra", Module.new)
-    s = Kernel.const_get("Sinatra")
-    s.const_set("Base", Module.new)
-  end
-
-  def clean_fake_sinatra
-    Kernel.const_unset("Sinatra") if defined?(Kernel::Sinatra)
-  end
 end

--- a/test/unit/instruments/active_record_test.rb
+++ b/test/unit/instruments/active_record_test.rb
@@ -38,6 +38,7 @@ class ActiveRecordTest < Minitest::Test
 
     instrument = ScoutApm::Instruments::ActiveRecord.new(agent_context)
     instrument.install(prepend: false)
+    clean_fake_rails
   end
 
   def test_modern_rails_initialization
@@ -50,6 +51,7 @@ class ActiveRecordTest < Minitest::Test
 
     instrument = ScoutApm::Instruments::ActiveRecord.new(agent_context)
     instrument.install(prepend: false)
+    clean_fake_rails
   end
 
   def test_instrumentation


### PR DESCRIPTION
I have an initializer with this config in my Rails 6 app:
```ruby
# Some configurations...

Rails.application.config.active_record.belongs_to_required_by_default = false

# More configurations...
```
After adding the `scout_apm_ruby` to my project, this config started not loading, which broke some features in my app. After investigating, I found that `scout_apm_ruby` was starting `ActiveRecord` without my config, this is happening because `install_via_after_initialize?` never returns true when Rails version is different from 3, which is a bug since all Rails versions above 3 can respond to `configuration` as well.

In this PR I fix this bug and add some tests to avoid regression.

