### PR TITLE
Add back PercentPolicy to SlowRequestPolicy

### DIFF
--- a/lib/scout_apm/slow_request_policy.rb
+++ b/lib/scout_apm/slow_request_policy.rb
@@ -14,7 +14,7 @@ module ScoutApm
 
     def add_default_policies
       add(SlowPolicy::SpeedPolicy.new(context))
-      add(SlowPolicy::PercentilePolicy.new(context))
+      add(SlowPolicy::PercentPolicy.new(context))
       add(SlowPolicy::AgePolicy.new(context))
       add(SlowPolicy::PercentilePolicy.new(context))
     end


### PR DESCRIPTION
I was noticing that I'm not getting a lot of traces for high-traffic endpoints, and I think this might be why? I think this PercentPolicy got lost in a refactor, and PercentilePolicy was listed twice instead. It does look like [PercentPolicy](https://github.com/scoutapp/scout_apm_ruby/blob/master/lib/scout_apm/slow_policy/percent_policy.rb) is the rule that helps track high traffic endpoints.

ref: https://github.com/scoutapp/scout_apm_ruby/commit/026f04ea77dde448da9d82b7456abbd849f5f315