### PR TITLE
Remove use of .blank? in ES converter

### DIFF
--- a/lib/scout_apm/layer_converters/external_service_converter.rb
+++ b/lib/scout_apm/layer_converters/external_service_converter.rb
@@ -53,7 +53,7 @@ module ScoutApm
       rescue
         # Do nothing
       ensure
-        domain = DEFAULT_DOMAIN if domain.to_s.blank?
+        domain = DEFAULT_DOMAIN if (domain.nil? || domain.empty?)
         domain
       end
 


### PR DESCRIPTION
Replaces `.blank?` and removes the need for ActiveSupport.

Closes #467 