### PR TITLE
Fix deprecation warning in Rails 7.1

### DIFF
--- a/lib/scout_apm/app_server_load.rb
+++ b/lib/scout_apm/app_server_load.rb
@@ -51,7 +51,7 @@ module ScoutApm
     ensure
       # Sometimes :database_engine and :database_adapter can cause a reference to an AR connection.
       # Make sure we release all AR connections held by this thread.
-      ActiveRecord::Base.clear_active_connections! if Utils::KlassHelper.defined?("ActiveRecord::Base")
+      ActiveRecord::Base.connection_handler.clear_active_connections! if Utils::KlassHelper.defined?("ActiveRecord::Base")
     end
 
     # Calls `.to_s` on the object passed in.


### PR DESCRIPTION
I recently upgraded my Rails app to 7.1, and am getting a lot of the following in my logs:

```
DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from clear_active_connections! at /Users/jamie/code/realworld-rails-hotwire/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.1/lib/active_record/connection_handling.rb:323)
```

Adding some extra debugging in active_record/connection_handling.rb pointed at lib/scout_apm/app_server_load.rb:54 being the _actual_ callsite in question.

I'm not sure how backward compatible this change is (or how old of Rails is supported by Scout) but this change does clear the deprecation.