### PR TITLE
Fix SyntaxError when instrumenting hash with shorthand

### DIFF
--- a/scout_apm.gemspec
+++ b/scout_apm.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake-compiler"
   s.add_development_dependency "addressable"
   s.add_development_dependency "activesupport"
-  s.add_runtime_dependency "parser"
+  s.add_runtime_dependency "parser", Gem::Version.new(RUBY_VERSION).approximate_recommendation
 
   # These are general development dependencies which are used in instrumentation
-  # tests. Specific versions are pulled in using specific gemfiles, e.g. 
+  # tests. Specific versions are pulled in using specific gemfiles, e.g.
   # `gems/rails3.gemfile`.
   s.add_development_dependency "activerecord"
   s.add_development_dependency "sqlite3"

--- a/test/unit/auto_instrument/hash_shorthand_controller-instrumented.rb
+++ b/test/unit/auto_instrument/hash_shorthand_controller-instrumented.rb
@@ -1,0 +1,36 @@
+
+class HashShorthandController < ApplicationController
+  def hash
+    json = {
+      static: "static",
+      shorthand: ::ScoutApm::AutoInstrument("shorthand:",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:6:in `hash'"]){shorthand},
+      longhand: ::ScoutApm::AutoInstrument("longhand: longhand",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:7:in `hash'"]){longhand},
+      longhand_different_key: ::ScoutApm::AutoInstrument("longhand",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:8:in `hash'"]){longhand},
+      hash_rocket: ::ScoutApm::AutoInstrument(":hash_rocket => hash_rocket",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:9:in `hash'"]){hash_rocket},
+      :hash_rocket_different_key => ::ScoutApm::AutoInstrument("hash_rocket",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:10:in `hash'"]){hash_rocket},
+      non_nil_receiver: ::ScoutApm::AutoInstrument("non_nil_receiver.value",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:11:in `hash'"]){non_nil_receiver.value},
+      nested: {
+        shorthand: ::ScoutApm::AutoInstrument("shorthand:",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:13:in `hash'"]){shorthand},
+      }
+    }
+    ::ScoutApm::AutoInstrument("render json:",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:16:in `hash'"]){render json:}
+  end
+
+  private
+
+  def shorthand
+    "shorthand"
+  end
+
+  def longhand
+    "longhand"
+  end
+
+  def hash_rocket
+    "hash_rocket"
+  end
+
+  def non_nil_receiver
+    ::ScoutApm::AutoInstrument("OpenStruct.new(value: \"value\")",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:34:in `non_nil_receiver'"]){OpenStruct.new(value: "value")}
+  end
+end

--- a/test/unit/auto_instrument/hash_shorthand_controller.rb
+++ b/test/unit/auto_instrument/hash_shorthand_controller.rb
@@ -1,0 +1,36 @@
+
+class HashShorthandController < ApplicationController
+  def hash
+    json = {
+      static: "static",
+      shorthand:,
+      longhand: longhand,
+      longhand_different_key: longhand,
+      :hash_rocket => hash_rocket,
+      :hash_rocket_different_key => hash_rocket,
+      non_nil_receiver: non_nil_receiver.value,
+      nested: {
+        shorthand:,
+      }
+    }
+    render json:
+  end
+
+  private
+
+  def shorthand
+    "shorthand"
+  end
+
+  def longhand
+    "longhand"
+  end
+
+  def hash_rocket
+    "hash_rocket"
+  end
+
+  def non_nil_receiver
+    OpenStruct.new(value: "value")
+  end
+end

--- a/test/unit/auto_instrument_test.rb
+++ b/test/unit/auto_instrument_test.rb
@@ -4,7 +4,7 @@ require 'scout_apm/auto_instrument'
 
 class AutoInstrumentTest < Minitest::Test
   ROOT = File.expand_path("../../", __dir__)
-  
+
   def source_path(name)
     File.expand_path("auto_instrument/#{name}.rb", __dir__)
   end
@@ -36,6 +36,12 @@ class AutoInstrumentTest < Minitest::Test
 
     assert_equal instrumented_source("controller"),
       normalize_backtrace(::ScoutApm::AutoInstrument::Rails.rewrite(source_path("controller")))
+  end
+
+  def test_controller_rewrite_hash_shorthand
+    skip if RUBY_VERSION < "3.1"
+    assert_equal instrumented_source("hash_shorthand_controller"),
+      normalize_backtrace(::ScoutApm::AutoInstrument::Rails.rewrite(source_path("hash_shorthand_controller")))
   end
 
   def test_rescue_from_rewrite


### PR DESCRIPTION
# Why

We get a `SyntaxError` when instrumenting hashes with [Ruby 3.1 hash shorthand syntax](https://rubyreferences.github.io/rubychanges/3.1.html#values-in-hash-literals-and-keyword-arguments-can-be-omitted) in controllers.

Fixes #484
Fixes #445

# Fix

Add a `on_hash` method that does the instrumentation correctly. 

@jrothrock - would you be the right person to ask for a review? Do let me know if there's a cleaner way to do this.

# Testing

I've added test cases.

@natematykiewicz - if you would like to, you may test this with your app.
