### PR TITLE
Fix nested_call edge case

### DIFF
--- a/lib/scout_apm/auto_instrument/rails.rb
+++ b/lib/scout_apm/auto_instrument/rails.rb
@@ -142,7 +142,7 @@ module ScoutApm
             key_node, value_node = pair.children
             next unless key_node.type == :sym && value_node.type == :send
             key = key_node.children[0]
-            next unless value_node.children[0].nil? && key == value_node.children[1]
+            next unless value_node.children.size == 2 && value_node.children[0].nil? && key == value_node.children[1]
 
             # Extract useful metadata for instrumentation:
             line = pair.location.line || 'line?'

--- a/test/unit/auto_instrument/hash_shorthand_controller-instrumented.rb
+++ b/test/unit/auto_instrument/hash_shorthand_controller-instrumented.rb
@@ -11,12 +11,17 @@ class HashShorthandController < ApplicationController
       non_nil_receiver: ::ScoutApm::AutoInstrument("non_nil_receiver.value",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:11:in `hash'"]){non_nil_receiver.value},
       nested: {
         shorthand: ::ScoutApm::AutoInstrument("shorthand:",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:13:in `hash'"]){shorthand},
-      }
+      },
+      nested_call: ::ScoutApm::AutoInstrument("nested_call(params[\"timestamp\"])",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:15:in `hash'"]){nested_call(params["timestamp"])}
     }
-    ::ScoutApm::AutoInstrument("render json:",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:16:in `hash'"]){render json:}
+    ::ScoutApm::AutoInstrument("render json:",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:17:in `hash'"]){render json:}
   end
 
   private
+
+  def nested_call(noop)
+    noop
+  end
 
   def shorthand
     "shorthand"
@@ -31,6 +36,6 @@ class HashShorthandController < ApplicationController
   end
 
   def non_nil_receiver
-    ::ScoutApm::AutoInstrument("OpenStruct.new(value: \"value\")",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:34:in `non_nil_receiver'"]){OpenStruct.new(value: "value")}
+    ::ScoutApm::AutoInstrument("OpenStruct.new(value: \"value\")",["ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:39:in `non_nil_receiver'"]){OpenStruct.new(value: "value")}
   end
 end

--- a/test/unit/auto_instrument/hash_shorthand_controller.rb
+++ b/test/unit/auto_instrument/hash_shorthand_controller.rb
@@ -11,12 +11,17 @@ class HashShorthandController < ApplicationController
       non_nil_receiver: non_nil_receiver.value,
       nested: {
         shorthand:,
-      }
+      },
+      nested_call: nested_call(params["timestamp"])
     }
     render json:
   end
 
   private
+
+  def nested_call(noop)
+    noop
+  end
 
   def shorthand
     "shorthand"


### PR DESCRIPTION
# What

@jrothrock @natematykiewicz - I missed an edge case in #486

The `replace` action in `on_hash` should ideally run only for the case where the Ruby 3.1 hash shorthand syntax is used. If the `value_node` takes in an argument, we can be sure it's not the shorthand syntax case. This PR adds a check for that: 

```rb
value_node.children.size == 2
```

# Test

Without the change, `params["timestamp"]` gets dropped:

```rb
# Prior to this PR
nested_call: ::ScoutApm::AutoInstrument(\"nested_call: nested_call(params[\\\"timestamp\\\"])\",[\"ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:15:in `hash'\"]){nested_call}
# Fixed
nested_call: ::ScoutApm::AutoInstrument(\"nested_call(params[\\\"timestamp\\\"])\",[\"ROOT/test/unit/auto_instrument/hash_shorthand_controller.rb:15:in `hash'\"]){nested_call(params[\"timestamp\"])}
```

leading to errors like `wrong number of arguments (given 0, expected 1) (ArgumentError)`.