### PR TITLE
Fix parser dependency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,10 @@ Add the gem to your Gemfile
 
     gem 'scout_apm'
 
+Add [a version of the `parser` gem that supports your version of Ruby](https://github.com/whitequark/parser?tab=readme-ov-file#backwards-compatibility). For example, if you're on Ruby 3.3.0:
+
+    gem 'parser', '~> 3.3.0.0'
+
 Update your Gemfile
 
     bundle install

--- a/scout_apm.gemspec
+++ b/scout_apm.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake-compiler"
   s.add_development_dependency "addressable"
   s.add_development_dependency "activesupport"
-  s.add_runtime_dependency "parser", Gem::Version.new(RUBY_VERSION).approximate_recommendation
+  s.add_runtime_dependency "parser"
 
   # These are general development dependencies which are used in instrumentation
   # tests. Specific versions are pulled in using specific gemfiles, e.g.


### PR DESCRIPTION
# Why

If you're on Ruby 3 and  version 3.x of the `parser`gem, when you upgrade the `scout_apm` gem to 5.3.6, you will no longer be able to `bundle install`. Sample error:

```
Could not find compatible versions

Because scout_apm >= 5.3.6 depends on parser ~> 2.6
  and Gemfile depends on scout_apm = 5.3.6,
  parser ~> 2.6 is required.
So, because Gemfile depends on parser ~> 3.3.0,
  version solving has failed.
```

It looks like `gemspecs` are not evaluated dynamically on your local machine, but when the gem is published:

```
> gem dependency scout_apm -v 5.3.6 --remote
Gem scout_apm-5.3.6
  activerecord (>= 0, development)
  activesupport (>= 0, development)
  addressable (>= 0, development)
  guard (>= 0, development)
  guard-minitest (>= 0, development)
  m (>= 0, development)
  minitest (>= 0, development)
  mocha (>= 0, development)
  parser (~> 2.6)
  pry (>= 0, development)
  rake-compiler (>= 0, development)
  rubocop (>= 0, development)
  simplecov (>= 0, development)
  sqlite3 (>= 0, development)
```

@jrothrock @natematykiewicz 

# What 

Reverses [this change](https://github.com/scoutapp/scout_apm_ruby/pull/486#discussion_r1464850727) in #486.

I'm not sure if we should be putting a warning somewhere in the `scout_apm` gem, but the parser gem gives a warning like this (not sure about older versions), which might suffice:

```
> rails server
...
warning: parser/current is loading parser/ruby32, which recognizes 3.2.3-compliant syntax, but you are running 3.2.2.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```