### PR TITLE
Don't capture queue time for websocket requests

### DIFF
--- a/lib/scout_apm/layer_converters/request_queue_time_converter.rb
+++ b/lib/scout_apm/layer_converters/request_queue_time_converter.rb
@@ -4,6 +4,8 @@ module ScoutApm
 
       HEADERS = %w(X-Queue-Start X-Request-Start X-QUEUE-START X-REQUEST-START x-queue-start x-request-start)
 
+      WEBSOCKET_HEADERS = %w(SEC_WEBSOCKET_VERSION Sec-WebSocket-Version SEC_WEBSOCKET_PROTOCOL Sec-WebSocket-Protocol SEC_WEBSOCKET_KEY Sec-WebSocket-Key)
+
       def headers
         request.headers
       end
@@ -14,6 +16,8 @@ module ScoutApm
         return unless context.config.value('record_queue_time')
 
         return unless headers
+
+        return if request_over_websocket?
 
         raw_start = locate_timestamp
         return unless raw_start
@@ -37,6 +41,10 @@ module ScoutApm
       end
 
       private
+
+      def request_over_websocket?
+        WEBSOCKET_HEADERS.any? { |header| headers[header] }
+      end
 
       # Looks through the possible headers with this data, and extracts the raw
       # value of the header

--- a/lib/scout_apm/layer_converters/request_queue_time_converter.rb
+++ b/lib/scout_apm/layer_converters/request_queue_time_converter.rb
@@ -17,6 +17,7 @@ module ScoutApm
 
         return unless headers
 
+        # When an application uses TurboStreams, we capture very innaccurate queue times.
         return if request_over_websocket?
 
         raw_start = locate_timestamp

--- a/lib/scout_apm/layer_converters/request_queue_time_converter.rb
+++ b/lib/scout_apm/layer_converters/request_queue_time_converter.rb
@@ -4,8 +4,6 @@ module ScoutApm
 
       HEADERS = %w(X-Queue-Start X-Request-Start X-QUEUE-START X-REQUEST-START x-queue-start x-request-start)
 
-      WEBSOCKET_HEADERS = %w(SEC_WEBSOCKET_VERSION Sec-WebSocket-Version SEC_WEBSOCKET_PROTOCOL Sec-WebSocket-Protocol SEC_WEBSOCKET_KEY Sec-WebSocket-Key)
-
       def headers
         request.headers
       end
@@ -17,7 +15,7 @@ module ScoutApm
 
         return unless headers
 
-        # When an application uses TurboStreams, we capture very innaccurate queue times.
+        # When an application uses Turbo Streams, we capture very innaccurate queue times.
         return if request_over_websocket?
 
         raw_start = locate_timestamp
@@ -44,7 +42,7 @@ module ScoutApm
       private
 
       def request_over_websocket?
-        WEBSOCKET_HEADERS.any? { |header| headers[header] }
+        headers["Upgrade"] == "websocket"
       end
 
       # Looks through the possible headers with this data, and extracts the raw


### PR DESCRIPTION
With the use of libraries such as Stimulus Reflex, which under the hood utilize Turbo Streams, we can run into issues where the queue times that we report are very inaccurate.

They appear to have the same queue time header/timestamp as when the connection was first created, and is not changed for subsequent data sent over the websocket. This leads to an ever growing queue time as long as the connection isn't terminated.