### PR TITLE
Freeze string literals in AutoInstrument layer

### DIFF
--- a/lib/scout_apm/auto_instrument/layer.rb
+++ b/lib/scout_apm/auto_instrument/layer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module ScoutApm
   def self.AutoInstrument(name, backtrace)

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 # A TrackedRequest is a stack of layers, where completed layers (go into, then
 # come out of a layer) are forgotten as they finish. Layers are attached to
 # their children as the process goes, building a tree structure within the


### PR DESCRIPTION
I think if you have a lot of AutoInstrumentation going on, this results in a lot of repeated memory allocations for the same string.

Addresses #495

I tested this out in our staging environment and it does remove the string allocations from strings in these files. I don't know if this is meaningful at all or if it's worth doing it piecemeal like this, versus just adding the pragma to everything or relying on the user to pass some Ruby options to freeze all string literals.