### PR TITLE
fix deprecation warning Bundler.rubygems.all_specs

### DIFF
--- a/lib/scout_apm/utils/installed_gems.rb
+++ b/lib/scout_apm/utils/installed_gems.rb
@@ -12,7 +12,8 @@ module ScoutApm
       end
 
       def run
-        Bundler.rubygems.all_specs.map {|spec| [spec.name, spec.version.to_s] }
+        specs = Bundler.rubygems.public_send(Bundler.rubygems.respond_to?(:installed_specs) ? :installed_specs : :all_specs)
+        specs.map { |spec| [spec.name, spec.version.to_s] }
       rescue => e
         logger.warn("Couldn't fetch Gem information: #{e.message}")
         []


### PR DESCRIPTION
- fix deprecation warning when starting `rails server`
  - `[DEPRECATED] Bundler.rubygems.all_specs has been removed in favor of Bundler.rubygems.installed_specs`
- reproducible with ruby v3.3.3+ (and new minimum required bundler v2.5.11, rubygems v3.5.11 versions)

#### Link
- https://github.com/rubygems/rubygems/pull/7673

Fixes #513 

/cc @mpvosseller