### PR TITLE
Respect ignored requests on find

### DIFF
--- a/lib/scout_apm/request_manager.rb
+++ b/lib/scout_apm/request_manager.rb
@@ -12,7 +12,6 @@ module ScoutApm
       req = Thread.current[:scout_request]
 
       # this ordering is important as if the req is set to be ignored it's also stopping and recorded
-      # binding.irb if req
       return req if req && req.ignoring_request?
 
       return if req && (req.stopping? || req.recorded?)

--- a/lib/scout_apm/request_manager.rb
+++ b/lib/scout_apm/request_manager.rb
@@ -13,7 +13,7 @@ module ScoutApm
 
       # this ordering is important as if the req is set to be ignored it's also stopping and recorded
       # binding.irb if req
-      return req if req&.ignoring_request?
+      return req if req & req.ignoring_request?
 
       return if req && (req.stopping? || req.recorded?)
 

--- a/lib/scout_apm/request_manager.rb
+++ b/lib/scout_apm/request_manager.rb
@@ -11,11 +11,13 @@ module ScoutApm
     def self.find
       req = Thread.current[:scout_request]
 
-      if req && (req.stopping? || req.recorded?)
-        nil
-      else
-        req
-      end
+      # this ordering is important as if the req is set to be ignored it's also stopping and recorded
+      # binding.irb if req
+      return req if req&.ignoring_request?
+
+      return if req && (req.stopping? || req.recorded?)
+
+      req
     end
 
     # Create a new TrackedRequest object for this thread

--- a/lib/scout_apm/request_manager.rb
+++ b/lib/scout_apm/request_manager.rb
@@ -13,7 +13,7 @@ module ScoutApm
 
       # this ordering is important as if the req is set to be ignored it's also stopping and recorded
       # binding.irb if req
-      return req if req & req.ignoring_request?
+      return req if req && req.ignoring_request?
 
       return if req && (req.stopping? || req.recorded?)
 


### PR DESCRIPTION
ensure we can set a request to be ignored in a background processing system via a before hook and the request manager should return the ignored request instead of creating a new one

related issues https://github.com/scoutapp/scout_apm_ruby/issues/336