### PR TITLE
Handle sqlite3 update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
             gemfile: gems/rails3.gemfile
           - ruby: 2.2
           - ruby: 2.3
+            gemfile: gems/sqlite3-1.3.gemfile
           - ruby: 2.4
+            gemfile: gems/sqlite3-1.3.gemfile
           - ruby: 2.5
           - ruby: 2.6
           - ruby: 2.6
@@ -31,9 +33,6 @@ jobs:
             test_features: "typhoeus"
           - ruby: 2.6
             gemfile: gems/octoshark.gemfile
-          - ruby: 2.6
-            gemfile: gems/rails3.gemfile
-            bundler: 1.17.3
           - ruby: 2.7
           - ruby: 2.7
             prepend: true

--- a/gems/sqlite3-1.3.gemfile
+++ b/gems/sqlite3-1.3.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile("../Gemfile")
+
+gem "sqlite3", "~> 1.3.5"

--- a/scout_apm.gemspec
+++ b/scout_apm.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   # tests. Specific versions are pulled in using specific gemfiles, e.g.
   # `gems/rails3.gemfile`.
   s.add_development_dependency "activerecord"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3",  "~> 1.4"
 
   s.add_development_dependency "rubocop"
   s.add_development_dependency "guard"


### PR DESCRIPTION
- Force lower version for older rubies. This is blunt, but should I don't believe it should introduce any new problems for anyone.