### PR TITLE
Fix: Undefined logger in grape instruments

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,4 +1,5 @@
 # Unreleased
+- Fix undeclared logger in grape instruments (#510)
 
 # 5.4.0
 * Add support for GoodJob (#506)

--- a/lib/scout_apm/instruments/grape.rb
+++ b/lib/scout_apm/instruments/grape.rb
@@ -53,7 +53,7 @@ module ScoutApm
                   self.options[:path].first,
           ].compact.map{ |n| n.to_s }.join("/")
         rescue => e
-          logger.info("Error getting Grape Endpoint Name. Error: #{e.message}. Options: #{self.options.inspect}")
+          ScoutApm::Agent.instance.context.logger.info("Error getting Grape Endpoint Name. Error: #{e.message}. Options: #{self.options.inspect}")
           name = "Grape/Unknown"
         end
 


### PR DESCRIPTION
While there is still an unknown issue getting the name for some `grape` endpoints, this at least resolves the undeclared `logger` variable, which will allow capturing the true issue.

I was unable to reproduce the name issue in my (relatively naive) testing.

Closes #510 