### PR TITLE
Instrument resque without forking

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 # Unreleased
 - Fix undeclared logger in grape instruments (#510)
 - Drop guaranteed support for Rubies <= 2.4
+- Instrument Resque without relying on forking per job (#514)
 
 # 5.4.0
 * Add support for GoodJob (#506)

--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -106,7 +106,6 @@ module ScoutApm
     # possible, it's no harm to have the "wrong" one also installed while running.
     def install_background_job_integrations
       context.environment.background_job_integrations.each do |int|
-        logger.info "resque_debug Attempting to install resque"
         int.install
         logger.info "Installed Background Job Integration [#{int.name}]"
       end

--- a/lib/scout_apm/agent.rb
+++ b/lib/scout_apm/agent.rb
@@ -106,6 +106,7 @@ module ScoutApm
     # possible, it's no harm to have the "wrong" one also installed while running.
     def install_background_job_integrations
       context.environment.background_job_integrations.each do |int|
+        logger.info "resque_debug Attempting to install resque"
         int.install
         logger.info "Installed Background Job Integration [#{int.name}]"
       end
@@ -208,7 +209,7 @@ module ScoutApm
 
       @error_service_background_worker = ScoutApm::BackgroundWorker.new(context, ERROR_SEND_FREQUENCY)
       @error_service_background_worker_thread = Thread.new do
-        @error_service_background_worker.start { 
+        @error_service_background_worker.start {
           periodic_work.run
         }
       end

--- a/lib/scout_apm/background_job_integrations/resque.rb
+++ b/lib/scout_apm/background_job_integrations/resque.rb
@@ -52,6 +52,8 @@ module ScoutApm
         end
       end
 
+      private
+
       def bind
         config.value("remote_agent_host")
       end

--- a/lib/scout_apm/background_job_integrations/resque.rb
+++ b/lib/scout_apm/background_job_integrations/resque.rb
@@ -25,6 +25,7 @@ module ScoutApm
       def install_before_first_fork
         ::Resque.before_first_fork do
           begin
+            # Don't check fork_per_job here in case some workers fork_per_job and some don't.
             if ScoutApm::Agent.instance.context.config.value('start_resque_server_instrument')
               ScoutApm::Agent.instance.start
               ScoutApm::Agent.instance.context.start_remote_server!(bind, port)

--- a/lib/scout_apm/background_job_integrations/resque.rb
+++ b/lib/scout_apm/background_job_integrations/resque.rb
@@ -27,6 +27,7 @@ module ScoutApm
 
       def install_before_first_fork
         ::Resque.before_first_fork do
+          ScoutApm::Agent.instance.context.logger.info "resque_debug Installing Resque before_first_fork"
           begin
             if ScoutApm::Agent.instance.context.config.value('start_resque_server_instrument')
               ScoutApm::Agent.instance.start

--- a/lib/scout_apm/background_job_integrations/resque.rb
+++ b/lib/scout_apm/background_job_integrations/resque.rb
@@ -30,12 +30,12 @@ module ScoutApm
               ScoutApm::Agent.instance.start
               ScoutApm::Agent.instance.context.start_remote_server!(bind, port)
             else
-              ScoutApm::Agent.instance.context.logger.info("Not starting remote server due to 'start_resque_server_instrument' setting")
+              logger.info("Not starting remote server due to 'start_resque_server_instrument' setting")
             end
           rescue Errno::EADDRINUSE
-            ScoutApm::Agent.instance.context.logger.warn "Error while Installing Resque Instruments, Port #{port} already in use. Set via the `remote_agent_port` configuration option"
+            logger.warn "Error while Installing Resque Instruments, Port #{port} already in use. Set via the `remote_agent_port` configuration option"
           rescue => e
-            ScoutApm::Agent.instance.context.logger.warn "Error while Installing Resque before_first_fork: #{e.inspect}"
+            logger.warn "Error while Installing Resque before_first_fork: #{e.inspect}"
           end
         end
       end
@@ -63,7 +63,11 @@ module ScoutApm
       end
 
       def config
-        @config || ScoutApm::Agent.instance.context.config
+        @config ||= ScoutApm::Agent.instance.context.config
+      end
+
+      def logger
+        @logger ||= ScoutApm::Agent.instance.context.logger
       end
     end
   end

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -57,7 +57,7 @@ module ScoutApm
       end
 
       def logger
-        @logger = ScoutApm::Agent.instance.context.logger
+        @logger ||= ScoutApm::Agent.instance.context.logger
       end
 
       def forking?

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -13,42 +13,17 @@ module ScoutApm
         @config || ScoutApm::Agent.instance.context.config
       end
 
-      # Insert ourselves into the point when resque turns a string "TestJob"
-      # into the class constant TestJob, and insert our instrumentation plugin
-      # into that constantized class
-      #
-      # This automates away any need for the user to insert our instrumentation into
-      # each of their jobs
-      # def inject_job_instrument
-      #   ::Resque::Job.class_eval do
-      #     def payload_class_with_scout_instruments
-      #       klass = payload_class_without_scout_instruments
-      #       klass.extend(ScoutApm::Instruments::Resque)
-      #       klass
-      #     end
-      #     alias_method :payload_class_without_scout_instruments, :payload_class
-      #     alias_method :payload_class, :payload_class_with_scout_instruments
-      #   end
-      # end
-
-      # def before_perform_scout_instrument(*args)
-      #   ScoutApm::Agent.instance.context.logger.info "resque_debug IN BEFORE PERFORM"
-      #   begin
-      #     ScoutApm::Agent.instance.context.become_remote_client!(bind, port)
-      #     # inject_job_instrument
-      #   rescue => e
-      #     ScoutApm::Agent.instance.context.logger.warn "Error while Installing Resque before_perform: #{e.inspect}"
-      #   end
-      # end
-
       def logger
         ScoutApm::Agent.instance.context.logger
       end
 
-      def around_perform_with_scout_instruments(*args)
-        logger.info "resque_debug IN AROUND PERFORM"
+      def before_perform_become_client(*args)
         ScoutApm::Agent.instance.context.become_remote_client!(bind, port)
-        logger.info "resque_debug REMOTE AGENT"
+        logger.debug "resque_debug REMOTE AGENT"
+      end
+
+      def around_perform_with_scout_instruments(*args)
+        logger.debug "resque_debug IN AROUND PERFORM"
         job_name = self.to_s
         queue = find_queue
 
@@ -57,7 +32,7 @@ module ScoutApm
           queue = args.first["queue_name"] rescue queue_name
         end
 
-        logger.info "resque_debug JOB: #{job_name} QUEUE: #{queue}"
+        logger.debug "resque_debug JOB: #{job_name} QUEUE: #{queue}"
 
         req = ScoutApm::RequestManager.lookup
 
@@ -69,14 +44,14 @@ module ScoutApm
           req.start_layer(ScoutApm::Layer.new('Job', job_name))
           started_job = true
 
-          logger.info "resque_debug DOING LAYERS"
+          logger.debug "resque_debug DOING LAYERS"
 
           yield
         rescue => e
           req.error!
           raise
         ensure
-          logger.info "resque_debug ENSURING"
+          logger.debug "resque_debug ENSURING"
           req.stop_layer if started_job
           req.stop_layer if started_queue
         end

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -24,7 +24,6 @@ module ScoutApm
       def before_perform_become_client(*args)
         # Don't become remote client if explicitly disabled or if forking is disabled to force synchronous recording.
         if ScoutApm::Agent.instance.context.config.value('start_resque_server_instrument') && forking?
-          logger.info "BECOMING REMOTE CLIENT"
           ScoutApm::Agent.instance.context.become_remote_client!(bind, port)
         else
           logger.debug("Not becoming remote client due to 'start_resque_server_instrument' setting or 'fork_per_job' setting")

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -1,29 +1,9 @@
 module ScoutApm
   module Instruments
     module Resque
-      def bind
-        config.value("remote_agent_host")
-      end
-
-      def port
-        config.value("remote_agent_port")
-      end
-
-      def config
-        @config || ScoutApm::Agent.instance.context.config
-      end
-
-      def logger
-        ScoutApm::Agent.instance.context.logger
-      end
-
-      def forking?
-        @forking ||= ENV["FORK_PER_JOB"] != "false"
-      end
-
       def before_perform_become_client(*args)
         # Don't become remote client if explicitly disabled or if forking is disabled to force synchronous recording.
-        if ScoutApm::Agent.instance.context.config.value('start_resque_server_instrument') && forking?
+        if config.value('start_resque_server_instrument') && forking?
           ScoutApm::Agent.instance.context.become_remote_client!(bind, port)
         else
           logger.debug("Not becoming remote client due to 'start_resque_server_instrument' setting or 'fork_per_job' setting")
@@ -60,6 +40,28 @@ module ScoutApm
         return @queue if @queue
         return queue if self.respond_to?(:queue)
         return "unknown"
+      end
+
+      private
+
+      def bind
+        config.value("remote_agent_host")
+      end
+
+      def port
+        config.value("remote_agent_port")
+      end
+
+      def config
+        @config || ScoutApm::Agent.instance.context.config
+      end
+
+      def logger
+        ScoutApm::Agent.instance.context.logger
+      end
+
+      def forking?
+        @forking ||= ENV["FORK_PER_JOB"] != "false"
       end
     end
   end

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -53,11 +53,11 @@ module ScoutApm
       end
 
       def config
-        @config || ScoutApm::Agent.instance.context.config
+        @config ||= ScoutApm::Agent.instance.context.config
       end
 
       def logger
-        ScoutApm::Agent.instance.context.logger
+        @logger = ScoutApm::Agent.instance.context.logger
       end
 
       def forking?

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -1,7 +1,54 @@
 module ScoutApm
   module Instruments
     module Resque
+      def bind
+        config.value("remote_agent_host")
+      end
+
+      def port
+        config.value("remote_agent_port")
+      end
+
+      def config
+        @config || ScoutApm::Agent.instance.context.config
+      end
+
+      # Insert ourselves into the point when resque turns a string "TestJob"
+      # into the class constant TestJob, and insert our instrumentation plugin
+      # into that constantized class
+      #
+      # This automates away any need for the user to insert our instrumentation into
+      # each of their jobs
+      # def inject_job_instrument
+      #   ::Resque::Job.class_eval do
+      #     def payload_class_with_scout_instruments
+      #       klass = payload_class_without_scout_instruments
+      #       klass.extend(ScoutApm::Instruments::Resque)
+      #       klass
+      #     end
+      #     alias_method :payload_class_without_scout_instruments, :payload_class
+      #     alias_method :payload_class, :payload_class_with_scout_instruments
+      #   end
+      # end
+
+      # def before_perform_scout_instrument(*args)
+      #   ScoutApm::Agent.instance.context.logger.info "resque_debug IN BEFORE PERFORM"
+      #   begin
+      #     ScoutApm::Agent.instance.context.become_remote_client!(bind, port)
+      #     # inject_job_instrument
+      #   rescue => e
+      #     ScoutApm::Agent.instance.context.logger.warn "Error while Installing Resque before_perform: #{e.inspect}"
+      #   end
+      # end
+
+      def logger
+        ScoutApm::Agent.instance.context.logger
+      end
+
       def around_perform_with_scout_instruments(*args)
+        logger.info "resque_debug IN AROUND PERFORM"
+        ScoutApm::Agent.instance.context.become_remote_client!(bind, port)
+        logger.info "resque_debug REMOTE AGENT"
         job_name = self.to_s
         queue = find_queue
 
@@ -10,7 +57,11 @@ module ScoutApm
           queue = args.first["queue_name"] rescue queue_name
         end
 
+        logger.info "resque_debug JOB: #{job_name} QUEUE: #{queue}"
+
         req = ScoutApm::RequestManager.lookup
+
+        # logger.info "resque_debug REQUEST: #{req.inspect}"
 
         begin
           req.start_layer(ScoutApm::Layer.new('Queue', queue))
@@ -18,11 +69,14 @@ module ScoutApm
           req.start_layer(ScoutApm::Layer.new('Job', job_name))
           started_job = true
 
+          logger.info "resque_debug DOING LAYERS"
+
           yield
         rescue => e
           req.error!
           raise
         ensure
+          logger.info "resque_debug ENSURING"
           req.stop_layer if started_job
           req.stop_layer if started_queue
         end

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -19,11 +19,11 @@ module ScoutApm
 
       def before_perform_become_client(*args)
         ScoutApm::Agent.instance.context.become_remote_client!(bind, port)
-        logger.debug "resque_debug REMOTE AGENT"
+        logger.info "resque_debug REMOTE AGENT"
       end
 
       def around_perform_with_scout_instruments(*args)
-        logger.debug "resque_debug IN AROUND PERFORM"
+        logger.info "resque_debug IN AROUND PERFORM"
         job_name = self.to_s
         queue = find_queue
 
@@ -32,7 +32,7 @@ module ScoutApm
           queue = args.first["queue_name"] rescue queue_name
         end
 
-        logger.debug "resque_debug JOB: #{job_name} QUEUE: #{queue}"
+        logger.info "resque_debug JOB: #{job_name} QUEUE: #{queue}"
 
         req = ScoutApm::RequestManager.lookup
 
@@ -44,14 +44,14 @@ module ScoutApm
           req.start_layer(ScoutApm::Layer.new('Job', job_name))
           started_job = true
 
-          logger.debug "resque_debug DOING LAYERS"
+          logger.info "resque_debug DOING LAYERS"
 
           yield
         rescue => e
           req.error!
           raise
         ensure
-          logger.debug "resque_debug ENSURING"
+          logger.info "resque_debug ENSURING"
           req.stop_layer if started_job
           req.stop_layer if started_queue
         end

--- a/lib/scout_apm/instruments/resque.rb
+++ b/lib/scout_apm/instruments/resque.rb
@@ -36,4 +36,3 @@ module ScoutApm
     end
   end
 end
-


### PR DESCRIPTION
- Inject ourselves into `Resque::Job`'s `payload_class` method upon initial setup so we don't rely on `after_fork`, which doesn't execute when `FORK_PER_JOB=false`. 
- Conditionally `become_remote_client` in instrumentation just like we `start_remote_server` based on `start_resque_server_instrument` config value. Also skip remote client if `FORK_PER_JOB=false`.
  -  if `FORK_PER_JOB=false`, the remote server/client recording is unnecessary and actually (silently) breaks it.