### PR TITLE
fix failing test with ruby 3.2 and 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,9 @@ jobs:
             test_features: "sidekiq_install"
           - ruby: 3.1
           - ruby: 3.2
+            gemfile: gems/sqlite3-v2.gemfile
           - ruby: 3.3
+            gemfile: gems/sqlite3-v2.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       SCOUT_TEST_FEATURES: ${{ matrix.test_features }}

--- a/gems/sqlite3-v2.gemfile
+++ b/gems/sqlite3-v2.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile("../Gemfile")
+
+gem "sqlite3", ">= 2.1"


### PR DESCRIPTION
Enhance CI configuration by adding sqlite3 gemfile for Ruby 3.2/3.3 in test matrix

🤷 Sorry, I have no idea why this change has an impact on the old failing ruby tests…