### PR TITLE
Filter env for error records

### DIFF
--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -50,6 +50,14 @@ require 'scout_apm/environment'
 # endpoint_sample_rate     - Rate to sample all endpoints. An integer between 0 and 100. 0 means no traces are sent, 100 means all traces are sent. (supercedes 'sample_rate')
 # job_sample_rate          - Rate to sample all jobs. An integer between 0 and 100. 0 means no traces are sent, 100 means all traces are sent. (supercedes 'sample_rate')
 #
+#
+# Errors Service Configuration
+# errors_enabled - true/false to enable the errors service
+# errors_ignored_exceptions - An array of exception classes to ignore.
+# errors_filtered_params - An array of parameter names to filter/redact out of error reports.
+# errors_env_capture - An array of environment variables to capture in error reports.
+# errors_host - The host to send error reports to.
+#
 # Any of these config settings can be set with an environment variable prefixed
 # by SCOUT_ and uppercasing the key: SCOUT_LOG_LEVEL for instance.
 
@@ -113,6 +121,7 @@ module ScoutApm
         'errors_enabled',
         'errors_ignored_exceptions',
         'errors_filtered_params',
+        'errors_env_capture',
         'errors_host',
     ]
 
@@ -232,6 +241,7 @@ module ScoutApm
       'errors_enabled' => BooleanCoercion.new,
       'errors_ignored_exceptions' => JsonCoercion.new,
       'errors_filtered_params' => JsonCoercion.new,
+      'errors_env_capture' => JsonCoercion.new,
     }
 
 
@@ -365,6 +375,7 @@ module ScoutApm
         'errors_enabled'                       => false,
         'errors_ignored_exceptions'            => %w(ActiveRecord::RecordNotFound ActionController::RoutingError),
         'errors_filtered_params'               => %w(password s3-key),
+        'errors_env_capture'                   => %w(),
         'errors_host'                          => 'https://errors.scoutapm.com',
       }.freeze
 

--- a/lib/scout_apm/error_service/payload.rb
+++ b/lib/scout_apm/error_service/payload.rb
@@ -35,7 +35,6 @@ module ScoutApm
           :message => error_record.message,
           :request_uri => error_record.request_uri,
           :request_params => error_record.request_params,
-          :request_session => error_record.request_session,
           :environment => error_record.environment,
           :trace => error_record.trace,
           :request_components => error_record.request_components,

--- a/test/unit/error_service/error_buffer_test.rb
+++ b/test/unit/error_service/error_buffer_test.rb
@@ -9,6 +9,34 @@ class ErrorBufferTest < Minitest::Test
     eb.capture(ex, env)
   end
 
+  def test_only_captures_relevant_environment
+    config = make_fake_config(
+      'errors_enabled' => true,
+      'errors_env_capture' => %w(ANOTHER_HEADER),
+      'collect_remote_ip' => true
+    )
+
+    test_context = ScoutApm::AgentContext.new().tap { |c| c.config = config }
+    ScoutApm::Agent.instance.stub(:context, test_context) do
+      eb = ScoutApm::ErrorService::ErrorBuffer.new(test_context)
+      eb.capture(ex, env)
+      exceptions = eb.instance_variable_get(:@error_records)
+      assert_equal 1, exceptions.length
+
+      exception = exceptions[0]
+      expected_env_keys = [
+        "ANOTHER_HEADER",
+        "HTTP_X_FORWARDED_FOR",
+        "HTTP_USER_AGENT",
+        "HTTP_REFERER",
+        "HTTP_ACCEPT_ENCODING",
+        "HTTP_ORIGIN",
+      ].to_set
+
+      assert_equal expected_env_keys, exception.environment.keys.to_set
+    end
+  end
+
   #### Helpers
 
   def context
@@ -16,7 +44,24 @@ class ErrorBufferTest < Minitest::Test
   end
 
   def env
-    {}
+    {
+      "REQUEST_METHOD" => "GET",
+      "SERVER_NAME" => "localhost",
+      "SERVER_PORT" => "3000",
+      "PATH_INFO" => "/test",
+      "HTTP_VERSION" => "HTTP/1.1",
+      "HTTP_USER_AGENT" => "TestAgent",
+      "HTTP_ACCEPT" => "text/html",
+      "HTTP_HOST" => "localhost:3000",
+      "HTTP_X_FORWARDED_FOR" => "123.345.67.89",
+      "HTTP_X_FORWARDED_PROTO" => "http",
+      "rack.url_scheme" => "http",
+      "REMOTE_ADDR" => "123.345.67.89",
+      "ANOTHER_HEADER" => "value",
+      "HTTP_REFERER" => "http://example.com",
+      "HTTP_ACCEPT_ENCODING" => "gzip, deflate",
+      "HTTP_ORIGIN" => "http://example.com",
+    }
   end
 
   def ex(msg="Whoops")

--- a/test/unit/error_test.rb
+++ b/test/unit/error_test.rb
@@ -7,6 +7,7 @@ class ErrorTest < Minitest::Test
   def test_captures_and_stores_exceptions_and_env
     config = make_fake_config(
       'errors_enabled' => true,
+      'errors_env_capture' => %w(),
     )
     test_context = ScoutApm::AgentContext.new().tap{|c| c.config = config }
     ScoutApm::Agent.instance.stub(:context, test_context) do


### PR DESCRIPTION
Updates the capturing of the environment for error records to be opt in as opposed to opt out with a few HTTP headers being automatically captured.