### PR TITLE
Add error monitoring to background job integrations

### DIFF
--- a/lib/scout_apm/background_job_integrations/faktory.rb
+++ b/lib/scout_apm/background_job_integrations/faktory.rb
@@ -60,8 +60,14 @@ module ScoutApm
           started_job = true
 
           yield
-        rescue
+        rescue Exception => e
           req.error!
+          env = {
+            :custom_controller => job_class(job),
+            :custom_action => queue
+          }
+          context = ScoutApm::Agent.instance.context
+          context.error_buffer.capture(e, env)
           raise
         ensure
           req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/faktory.rb
+++ b/lib/scout_apm/background_job_integrations/faktory.rb
@@ -60,14 +60,14 @@ module ScoutApm
           started_job = true
 
           yield
-        rescue Exception => e
+        rescue Exception => exception
           req.error!
           env = {
             :custom_controller => job_class(job),
             :custom_action => queue
           }
           context = ScoutApm::Agent.instance.context
-          context.error_buffer.capture(e, env)
+          context.error_buffer.capture(exception, env)
           raise
         ensure
           req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/good_job.rb
+++ b/lib/scout_apm/background_job_integrations/good_job.rb
@@ -34,8 +34,14 @@ module ScoutApm
               started_job = true # Following Convention
 
               block.call
-            rescue
+            rescue Exception => exception
               req.error!
+              env = {
+                :custom_controller => job.class.name,
+                :custom_action => job.queue_name.presence || UNKNOWN_QUEUE_PLACEHOLDER
+              }
+              context = ScoutApm::Agent.instance.context
+              context.error_buffer.capture(exception, env)
               raise
             ensure
               req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/legacy_sneakers.rb
+++ b/lib/scout_apm/background_job_integrations/legacy_sneakers.rb
@@ -42,14 +42,14 @@ module ScoutApm
           else
             super
           end
-        rescue Exception => e
+        rescue Exception => exception
           req.error!
           env = {
             :custom_controller => job_class,
             :custom_action => queue
           }
           context = ScoutApm::Agent.instance.context
-          context.error_buffer.capture(e, env)
+          context.error_buffer.capture(exception, env)
           raise
         ensure
           req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/legacy_sneakers.rb
+++ b/lib/scout_apm/background_job_integrations/legacy_sneakers.rb
@@ -42,8 +42,14 @@ module ScoutApm
           else
             super
           end
-        rescue Exception
+        rescue Exception => e
           req.error!
+          env = {
+            :custom_controller => job_class,
+            :custom_action => queue
+          }
+          context = ScoutApm::Agent.instance.context
+          context.error_buffer.capture(e, env)
           raise
         ensure
           req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/que.rb
+++ b/lib/scout_apm/background_job_integrations/que.rb
@@ -117,6 +117,12 @@ module ScoutApm
               _run_without_scout(*args)
             rescue Exception => e
               req.error!
+              env = {
+                :custom_controller => job_class,
+                :custom_action => queue
+              }
+              context = ScoutApm::Agent.instance.context
+              context.error_buffer.capture(e, env)
               raise
             ensure
               req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/que.rb
+++ b/lib/scout_apm/background_job_integrations/que.rb
@@ -115,14 +115,14 @@ module ScoutApm
               started_job = true
 
               _run_without_scout(*args)
-            rescue Exception => e
+            rescue Exception => exception
               req.error!
               env = {
                 :custom_controller => job_class,
                 :custom_action => queue
               }
               context = ScoutApm::Agent.instance.context
-              context.error_buffer.capture(e, env)
+              context.error_buffer.capture(exception, env)
               raise
             ensure
               req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/shoryuken.rb
+++ b/lib/scout_apm/background_job_integrations/shoryuken.rb
@@ -79,14 +79,14 @@ module ScoutApm
           started_job = true
 
           yield
-        rescue Exception => e
+        rescue Exception => exception
           req.error!
           env = {
             :custom_controller => job_class,
             :custom_action => queue
           }
           context = ScoutApm::Agent.instance.context
-          context.error_buffer.capture(e, env)
+          context.error_buffer.capture(exception, env)
           raise
         ensure
           req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/shoryuken.rb
+++ b/lib/scout_apm/background_job_integrations/shoryuken.rb
@@ -81,6 +81,12 @@ module ScoutApm
           yield
         rescue Exception => e
           req.error!
+          env = {
+            :custom_controller => job_class,
+            :custom_action => queue
+          }
+          context = ScoutApm::Agent.instance.context
+          context.error_buffer.capture(e, env)
           raise
         ensure
           req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/sneakers.rb
+++ b/lib/scout_apm/background_job_integrations/sneakers.rb
@@ -67,6 +67,12 @@ module ScoutApm
               process_work_without_scout(*args)
             rescue Exception => e
               req.error!
+              env = {
+                :custom_controller => job_class,
+                :custom_action => queue
+              }
+              context = ScoutApm::Agent.instance.context
+              context.error_buffer.capture(e, env)
               raise
             ensure
               req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/sneakers.rb
+++ b/lib/scout_apm/background_job_integrations/sneakers.rb
@@ -65,14 +65,14 @@ module ScoutApm
               started_job = true
 
               process_work_without_scout(*args)
-            rescue Exception => e
+            rescue Exception => exception
               req.error!
               env = {
                 :custom_controller => job_class,
                 :custom_action => queue
               }
               context = ScoutApm::Agent.instance.context
-              context.error_buffer.capture(e, env)
+              context.error_buffer.capture(exception, env)
               raise
             ensure
               req.stop_layer if started_job

--- a/lib/scout_apm/background_job_integrations/solid_queue.rb
+++ b/lib/scout_apm/background_job_integrations/solid_queue.rb
@@ -32,8 +32,14 @@ module ScoutApm
               started_job = true # Following Convention
 
               block.call
-            rescue
+            rescue Exception => exception
               req.error!
+              env = {
+                :custom_controller => job.class.name,
+                :custom_action => job.queue_name.presence || UNKNOWN_QUEUE_PLACEHOLDER
+              }
+              context = ScoutApm::Agent.instance.context
+              context.error_buffer.capture(exception, env)
               raise
             ensure
               req.stop_layer if started_job


### PR DESCRIPTION
## Changes
Implements error monitoring for the following frameworks
- SolidQueue --most important as this is default for ActiveJob handler since rails 7.2
- faktory
- goodjob
- que
- shoryuken
- sneakers (legacy support, but added for completeness) 


