### PR TITLE
Treat total time as exclusive time for limited layers in background jobs

### DIFF
--- a/lib/scout_apm/limited_layer.rb
+++ b/lib/scout_apm/limited_layer.rb
@@ -21,10 +21,13 @@ module ScoutApm
       @total_layers += 1
 
       @total_call_time += layer.total_call_time
-      @total_exclusive_time += layer.total_exclusive_time
+      # For limited layers, exclusive time should equal total time since limited layers
+      # report no children. As such, we need to consider all absorbed time as exclusive.
+      @total_exclusive_time += layer.total_call_time
 
       @total_allocations += layer.total_allocations
-      @total_exclusive_allocations += layer.total_exclusive_allocations
+      # Same logic applies to allocations
+      @total_exclusive_allocations += layer.total_allocations
     end
 
     def total_call_time

--- a/test/unit/limited_layer_test.rb
+++ b/test/unit/limited_layer_test.rb
@@ -18,16 +18,16 @@ class LimitedLayerTest < Minitest::Test
     ll = ScoutApm::LimitedLayer.new("ActiveRecord")
 
     ll.absorb faux_layer("ActiveRecord", "User#Find", 2, 1, 200, 100)
-    assert_equal 1, ll.total_exclusive_time
+    assert_equal 2, ll.total_exclusive_time
     assert_equal 2, ll.total_call_time
-    assert_equal 100, ll.total_exclusive_allocations
+    assert_equal 200, ll.total_exclusive_allocations
     assert_equal 200, ll.total_allocations
 
 
     ll.absorb faux_layer("ActiveRecord", "User#Find", 4, 3, 400, 300)
-    assert_equal 4, ll.total_exclusive_time           # 3 + 1
+    assert_equal 6, ll.total_exclusive_time           # 4 + 2 (for limited layers, should equal total time)
     assert_equal 6, ll.total_call_time                # 4 + 2
-    assert_equal 400, ll.total_exclusive_allocations  # 300 + 100
+    assert_equal 600, ll.total_exclusive_allocations  # 400 + 200 (same goes for allocations)
     assert_equal 600, ll.total_allocations            # 400 + 200
   end
 


### PR DESCRIPTION
This fixes an issue where we would not correctly bucket times with limited layers that could have child spans/instrumentation in background jobs (requests aren't impacted as they use span traces which utilizes a layer's start and stop time).

Essentially, this could only occur with custom instrumentation.

When we go to record the span / layer and assign it to its potential parent, a limited span will occur when a parent span, such as the Job entry point / root span, already has 2,000 spans added to it that are of the same type. Instead of creating more spans of that type on the parent span, we add a limited span/layer which then absorbs the additional time for that type for every iteration/span after 2,000. Limited layers don't contain children, and as such need to add what would have been the child's exclusive call time to its own exclusive time (which just ends up being the total time).

Instrumentation for libraries such as ActiveRecord and HTTP which can have many calls, and N+1s, would not be impacted. While these can have 1,000s+ of calls and become limited layers, these instrumentation spans stop / are closed before child spans can be added. In this case, the exclusive time and total call time would already be the same.

