### PR TITLE
Capture request method

### DIFF
--- a/lib/scout_apm/error_service/error_record.rb
+++ b/lib/scout_apm/error_service/error_record.rb
@@ -95,6 +95,7 @@ module ScoutApm
 
       # Capture params from env
       KEYS_TO_KEEP = [
+        "REQUEST_METHOD",
         "HTTP_USER_AGENT",
         "HTTP_REFERER",
         "HTTP_ACCEPT_ENCODING",

--- a/test/unit/error_service/error_buffer_test.rb
+++ b/test/unit/error_service/error_buffer_test.rb
@@ -25,6 +25,7 @@ class ErrorBufferTest < Minitest::Test
 
       exception = exceptions[0]
       expected_env_keys = [
+        "REQUEST_METHOD",
         "ANOTHER_HEADER",
         "HTTP_X_FORWARDED_FOR",
         "HTTP_USER_AGENT",


### PR DESCRIPTION
## Changes
- Adds `REQUEST_METHOD` to captured error context. The Scout APM errors service relies on this value to generate and display request info. 