### PR TITLE
Add NullableSampleRateCoercion for job_sample_rate

### DIFF
--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -221,6 +221,13 @@ module ScoutApm
       end
     end
 
+    class NullableSampleRateCoercion < SampleRateCoercion
+      def coerce(val)
+        return val if val.nil?
+        super(val)
+      end
+    end
+
     # Map of config keys to coercions.  Any key not listed here will be passed
     # through without modification.
 
@@ -247,7 +254,7 @@ module ScoutApm
       'sample_endpoints' => JsonCoercion.new,
       'sample_jobs' => JsonCoercion.new,
       'endpoint_sample_rate' => NullableIntegerCoercion.new,
-      'job_sample_rate' => NullableIntegerCoercion.new,
+      'job_sample_rate' => NullableSampleRateCoercion.new,
       'start_resque_server_instrument' => BooleanCoercion.new,
       'timeline_traces' => BooleanCoercion.new,
       'auto_instruments' => BooleanCoercion.new,

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -106,6 +106,20 @@ class ConfigTest < Minitest::Test
     assert_in_delta 0, coercion.coerce("-2.5")
   end
 
+  def test_nullable_sample_rate_coercion
+    coercion = ScoutApm::Config::NullableSampleRateCoercion.new
+    assert_nil coercion.coerce(nil)
+    assert_in_delta 1.0, coercion.coerce("1")
+    assert_in_delta 0.015, coercion.coerce("1.5")
+    assert_in_delta 1.0, coercion.coerce(1)
+    assert_in_delta 0.015, coercion.coerce(1.5)
+    assert_in_delta 0.0, coercion.coerce("0")
+    assert_in_delta 0.0, coercion.coerce(0)
+    assert_in_delta 0.0, coercion.coerce("")
+    assert_in_delta 0.5, coercion.coerce("0.5")
+    assert_in_delta 0, coercion.coerce("-2.5")
+  end
+
   def test_any_keys_found
     ENV.stubs(:has_key?).returns(nil)
 


### PR DESCRIPTION
User who have already defined `job_sample_rate` before would end up with inconsistent behaviors.