### PR TITLE
Update Puma hooks format for 7.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,8 +1,10 @@
 ## Pending
 - Add Prism AutoInstruments Support (#582) (#587)
+- Add HTTPX instrumentation (#588)
 - Fix user error context being incorrectly flattened (#581)
 - Handle Delayed Job PerformableMethod jobs for error tracking (#584)
 - Require 'httpclient' library on instrumentation install (#586)
+- Add support for Puma 7.0 hook format (#589)
 
 # 5.8.0
 - Add error monitoring to SolidQueue, faktory, goodjob, que, shoryuken, sneakers (#571)


### PR DESCRIPTION
Closes #572 

The hooks format changed in 7.0 to have more of a structure:
https://github.com/puma/puma/commit/b16790f7a3c1bfc1847225a58897c9fbd19981f8#diff-122c03b9c96f060a9cc29b5ed3446467e1909b0054b4f5cfd95ee41cfff832e7R1469-R1470