### PR TITLE
Add ability to capture sidekiq job args as context

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,9 @@
 ## Pending
 - Add Prism AutoInstruments Support (#582) (#587)
 - Add HTTPX instrumentation (#588)
+- Add ability to automatically capture Sidekiq job args as context
+  - `job_params_capture` - Set to true to enable job argument capturing
+  - `job_params_filter`  - A list of arguments to filter (automatically includes Rails filtered_parameters) 
 - Fix user error context being incorrectly flattened (#581)
 - Handle Delayed Job PerformableMethod jobs for error tracking (#584)
 - Require 'httpclient' library on instrumentation install (#586)

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -29,6 +29,8 @@ require 'scout_apm/environment'
 # report_format    - 'json' or 'marshal'. Marshal is legacy and will be removed.
 # scm_subdirectory - if the app root lives in source management in a subdirectory. E.g. #{SCM_ROOT}/src
 # uri_reporting    - 'path' or 'full_path' default is 'full_path', which reports URL params as well as the path.
+# job_params_capture - true/false to enable capturing of job args in the context.
+# job_filtered_params - An array of job argument names to filter/redact out of job reports.
 # record_queue_time - true/false to enable recording of queuetime.
 # remote_agent_host - Internal: What host to bind to, and also send messages to for remote. Default: 127.0.0.1.
 # remote_agent_port - What port to bind the remote webserver to
@@ -96,6 +98,8 @@ module ScoutApm
         'profile',
         'proxy',
         'record_queue_time',
+        'job_params_capture',
+        'job_filtered_params',
         'remote_agent_host',
         'remote_agent_port',
         'report_format',
@@ -226,6 +230,8 @@ module ScoutApm
       'external_service_metric_report_limit' => IntegerCoercion.new,
       'instrument_http_url_length' => IntegerCoercion.new,
       'record_queue_time' => BooleanCoercion.new,
+      'job_params_capture' => BooleanCoercion.new,
+      'job_filtered_params' => JsonCoercion.new,
       'sample_rate' => IntegerCoercion.new,
       'sample_endpoints' => JsonCoercion.new,
       'sample_jobs' => JsonCoercion.new,
@@ -364,6 +370,8 @@ module ScoutApm
         'job_sample_rate'                      => nil,
         'start_resque_server_instrument'       => true, # still only starts if Resque is detected
         'collect_remote_ip'                    => true,
+        'job_params_capture'                   => false,
+        'job_filtered_params'                  => [],
         'record_queue_time'                    => true,
         'timeline_traces'                      => true,
         'auto_instruments'                     => false,

--- a/lib/scout_apm/context.rb
+++ b/lib/scout_apm/context.rb
@@ -7,6 +7,8 @@ module ScoutApm
   class Context
     attr_reader :context
 
+    VALID_TYPES = [String, Symbol, Numeric, Time, Date, TrueClass, FalseClass]
+
     def initialize(context)
       @context = context
       @extra = {}
@@ -93,7 +95,7 @@ module ScoutApm
       value = key_value.values.last
       if value.nil?
         false # don't log this ... easy to happen
-      elsif !valid_type?([String, Symbol, Numeric, Time, Date, TrueClass, FalseClass],value)
+      elsif !valid_type?(VALID_TYPES, value)
         logger.info "The value for [#{key_value.keys.first}] is not a valid type [#{value.class}]."
         false
       else

--- a/test/unit/instruments/httpx_test.rb
+++ b/test/unit/instruments/httpx_test.rb
@@ -42,7 +42,7 @@ if (ENV["SCOUT_TEST_FEATURES"] || "").include?("instruments")
 
     def test_httpx_request_retry
       begin
-        HTTPX.with(timeout: { connect_timeout: 0.1, request_timeout: 0.1 })
+        HTTPX.with(timeout: { connect_timeout: 0.25, request_timeout: 0.25 })
              .get("https://httpbin.org/delay/5")
       rescue
       end


### PR DESCRIPTION
Closes #569 

Adds the ability to capture job args as context. 

This has been tested down to sidekiq 6.0+, but may work for earlier versions. By default this configuration will be off:
`job_params_capture => false`
`job_filtered_params => []` (Rails filter_parameters are also used for filtering params.)

This also has the added benefit of adding context to error exceptions occurring in jobs.