### PR TITLE
Fix HTTP instrumentation for http gem v6.0+

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,7 @@
 # Pending
 
+- Fix compatibility with `http >= 6.0.0` (#613)
+
 # 6.1.1
 
 - Fix Redis 5 prepend interaction (#611)

--- a/lib/scout_apm/instruments/http.rb
+++ b/lib/scout_apm/instruments/http.rb
@@ -24,29 +24,62 @@ module ScoutApm
 
           if prepend
             ::HTTP::Client.send(:include, ScoutApm::Tracer)
-            ::HTTP::Client.send(:prepend, HTTPInstrumentationPrepend)
+            if http_version_at_least?("6.0.0")
+              ::HTTP::Client.send(:prepend, HTTPInstrumentationPrependV6)
+            else
+              ::HTTP::Client.send(:prepend, HTTPInstrumentationPrepend)
+            end
           else
-            ::HTTP::Client.class_eval do
-              include ScoutApm::Tracer
+            if http_version_at_least?("6.0.0")
+              ::HTTP::Client.class_eval do
+                include ScoutApm::Tracer
 
-              def request_with_scout_instruments(verb, uri, opts = {})
-                self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
-                  request_without_scout_instruments(verb, uri, opts)
+                def request_with_scout_instruments(verb, uri, **opts)
+                  self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
+                    request_without_scout_instruments(verb, uri, **opts)
+                  end
                 end
-              end
 
-              def request_scout_description(verb, uri)
-                max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
-                (String(uri).split('?').first)[0..(max_length - 1)]
-              rescue
-                ""
-              end
+                def request_scout_description(verb, uri)
+                  max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+                  (String(uri).split('?').first)[0..(max_length - 1)]
+                rescue
+                  ""
+                end
 
-              alias request_without_scout_instruments request
-              alias request request_with_scout_instruments
+                alias request_without_scout_instruments request
+                alias request request_with_scout_instruments
+              end
+            else
+              ::HTTP::Client.class_eval do
+                include ScoutApm::Tracer
+
+                def request_with_scout_instruments(verb, uri, opts = {})
+                  self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
+                    request_without_scout_instruments(verb, uri, opts)
+                  end
+                end
+
+                def request_scout_description(verb, uri)
+                  max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+                  (String(uri).split('?').first)[0..(max_length - 1)]
+                rescue
+                  ""
+                end
+
+                alias request_without_scout_instruments request
+                alias request request_with_scout_instruments
+              end
             end
           end
         end
+      end
+
+      private
+
+      def http_version_at_least?(version)
+        defined?(::HTTP::VERSION) &&
+          Gem::Version.new(::HTTP::VERSION) >= Gem::Version.new(version)
       end
     end
 
@@ -54,6 +87,21 @@ module ScoutApm
       def request(verb, uri, opts = {})
         self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
           super(verb, uri, opts)
+        end
+      end
+
+      def request_scout_description(verb, uri)
+        max_length = ScoutApm::Agent.instance.context.config.value('instrument_http_url_length')
+        (String(uri).split('?').first)[0..(max_length - 1)]
+      rescue
+        ""
+      end
+    end
+
+    module HTTPInstrumentationPrependV6
+      def request(verb, uri, **opts)
+        self.class.instrument("HTTP", verb, :ignore_children => true, :desc => request_scout_description(verb, uri)) do
+          super(verb, uri, **opts)
         end
       end
 

--- a/test/unit/instruments/http_test.rb
+++ b/test/unit/instruments/http_test.rb
@@ -15,9 +15,14 @@ if (ENV["SCOUT_TEST_FEATURES"] || "").include?("instruments")
 
     def test_installs_using_proper_method
       if @instrument_manager.prepend_for_instrument?(@instance.class) == true
-        assert ::HTTP::Client.ancestors.include?(ScoutApm::Instruments::HTTPInstrumentationPrepend)
+        if Gem::Version.new(::HTTP::VERSION) >= Gem::Version.new("6.0.0")
+          assert ::HTTP::Client.ancestors.include?(ScoutApm::Instruments::HTTPInstrumentationPrependV6)
+        else
+          assert ::HTTP::Client.ancestors.include?(ScoutApm::Instruments::HTTPInstrumentationPrepend)
+        end
       else
         assert_equal false, ::HTTP::Client.ancestors.include?(ScoutApm::Instruments::HTTPInstrumentationPrepend)
+        assert_equal false, ::HTTP::Client.ancestors.include?(ScoutApm::Instruments::HTTPInstrumentationPrependV6)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Fixes #613 — `ArgumentError: wrong number of arguments (given 3, expected 2)` when using http gem v6.0+
- http gem v6.0 changed `HTTP::Client#request` from positional args `(verb, uri, opts = {})` to keyword args `(verb, uri, **opts)`
- Adds version detection via `Gem::Version` and separate instrumentation paths for v5 (positional) and v6+ (keyword) in both the prepend and alias code paths

## Test plan

- [x] Existing HTTP instrumentation test updated and passes with http gem v6.0.2
- [x] Full test suite (284 tests) passes with no regressions
- [x] Verify with http gem v5.x to confirm backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)