### PR TITLE
Set timeouts on the reporting HTTP connection

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,7 @@
 # Pending
 
+- Set timeouts on the reporting HTTP connection so a slow or unreachable Scout host can no longer block the reporting thread indefinitely (previously fell back to Net::HTTP's 60s default). Configurable via `connect_timeout` / `read_timeout` (both default 5s).
+
 # 6.2.0
 
 - Fix compatibility with `http >= 6.0.0` (#613)

--- a/lib/scout_apm/config.rb
+++ b/lib/scout_apm/config.rb
@@ -12,6 +12,7 @@ require 'scout_apm/environment'
 # application_root - override the detected directory of the application
 # collect_remote_ip - automatically capture user's IP into a Trace's Context
 # compress_payload - true/false to enable gzipping of payload
+# connect_timeout  - seconds to wait when opening a connection to the reporting host before giving up. Default: 5
 # data_file        - override the default temporary storage location. Must be a location in a writable directory
 # dev_trace        - true or false. Enables always-on tracing in development environmen only
 # direct_host      - override the default "direct" host. The direct_host bypasses the ingestion pipeline and goes directly to the webserver, and is primarily used for features under development.
@@ -26,6 +27,7 @@ require 'scout_apm/environment'
 # name             - override the name reported to APM. This is the name that shows in the Web UI
 # profile          - turn on/off scoutprof (only applicable in Gem versions including scoutprof)
 # proxy            - an http proxy
+# read_timeout     - seconds to wait for a response from the reporting host before giving up. Default: 5
 # report_format    - 'json' or 'marshal'. Marshal is legacy and will be removed.
 # scm_subdirectory - if the app root lives in source management in a subdirectory. E.g. #{SCM_ROOT}/src
 # uri_reporting    - 'path' or 'full_path' default is 'full_path', which reports URL params as well as the path.
@@ -71,6 +73,7 @@ module ScoutApm
         'collect_remote_ip',
         'compress_payload',
         'config_file',
+        'connect_timeout',
         'data_file',
         'database_metric_limit',
         'database_metric_report_limit',
@@ -97,6 +100,7 @@ module ScoutApm
         'name',
         'profile',
         'proxy',
+        'read_timeout',
         'record_queue_time',
         'job_params_capture',
         'job_filtered_params',
@@ -244,6 +248,8 @@ module ScoutApm
       'monitor' => BooleanCoercion.new,
       'collect_remote_ip' => BooleanCoercion.new,
       'compress_payload' => BooleanCoercion.new,
+      'connect_timeout' => IntegerCoercion.new,
+      'read_timeout' => IntegerCoercion.new,
       'database_metric_limit'  => IntegerCoercion.new,
       'database_metric_report_limit' => IntegerCoercion.new,
       'external_service_metric_limit'  => IntegerCoercion.new,
@@ -362,6 +368,7 @@ module ScoutApm
     class ConfigDefaults
       DEFAULTS = {
         'compress_payload'                     => true,
+        'connect_timeout'                      => 5,    # seconds; Net::HTTP open_timeout for reporting
         'detailed_middleware'                  => false,
         'dev_trace'                            => false,
         'direct_host'                          => 'https://apm.scoutapp.com',
@@ -374,6 +381,7 @@ module ScoutApm
         'log_level'                            => 'info',
         'max_traces'                           => 10,
         'profile'                              => true, # for scoutprof
+        'read_timeout'                         => 5,    # seconds; Net::HTTP read_timeout for reporting
         'report_format'                        => 'json',
         'scm_subdirectory'                     => '',
         'uri_reporting'                        => 'full_path',

--- a/lib/scout_apm/reporter.rb
+++ b/lib/scout_apm/reporter.rb
@@ -124,6 +124,16 @@ module ScoutApm
                               proxy_uri.port,
                               proxy_uri.user,
                               proxy_uri.password).new(url.host, url.port)
+
+      # Bound how long a single reporting attempt can block. Without these,
+      # Net::HTTP falls back to a 60s default and a slow or unreachable host
+      # leaves the reporting thread stuck inside a native call (DNS, TLS,
+      # socket read). That is especially dangerous in a preloaded/forking app
+      # server, where a thread blocked there at fork() time can leave the
+      # forked worker holding a lock that no surviving thread will release.
+      http.open_timeout = config.value("connect_timeout")
+      http.read_timeout = config.value("read_timeout")
+
       if url.is_a?(URI::HTTPS)
         http.use_ssl = true
         http.ca_file = config.value("ssl_cert_file")

--- a/test/unit/reporter_test.rb
+++ b/test/unit/reporter_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+require 'scout_apm/reporter'
+
+class ReporterTest < Minitest::Test
+  def setup
+    @context = ScoutApm::AgentContext.new
+  end
+
+  # Build a Config with the given overrides taking precedence, but still
+  # backed by the real defaults & coercions.
+  def config_with(overrides = {})
+    overlays = [
+      FakeConfigOverlay.new(overrides),
+      ScoutApm::Config::ConfigDefaults.new,
+      ScoutApm::Config::ConfigNull.new,
+    ]
+    ScoutApm::Config.new(@context, overlays)
+  end
+
+  def reporter_for(overrides = {})
+    @context.config = config_with(overrides)
+    ScoutApm::Reporter.new(@context, :checkin)
+  end
+
+  def https_uri
+    URI.parse("https://checkin.scoutapp.com/apps/checkin.scout")
+  end
+
+  def test_sets_default_timeouts_on_http_connection
+    http = reporter_for.send(:http, https_uri)
+
+    assert_equal 5, http.open_timeout
+    assert_equal 5, http.read_timeout
+  end
+
+  def test_honors_configured_timeouts
+    http = reporter_for('connect_timeout' => 2, 'read_timeout' => 3).send(:http, https_uri)
+
+    assert_equal 2, http.open_timeout
+    assert_equal 3, http.read_timeout
+  end
+
+  def test_coerces_string_timeouts_from_env
+    http = reporter_for('connect_timeout' => "7", 'read_timeout' => "8").send(:http, https_uri)
+
+    assert_equal 7, http.open_timeout
+    assert_equal 8, http.read_timeout
+  end
+
+  def test_sets_timeouts_for_plain_http_endpoints_too
+    http = reporter_for.send(:http, URI.parse("http://checkin.scoutapp.com/apps/checkin.scout"))
+
+    refute http.use_ssl?
+    assert_equal 5, http.open_timeout
+    assert_equal 5, http.read_timeout
+  end
+end


### PR DESCRIPTION
## Background

A customer running on AWS Fargate (Puma cluster with `preload_app!`, plus a separate good_job container) saw deploys go from ~2 min to ~11 min and frequently fail — Puma would log boot but never reach `Listening`, so health checks never passed. Setting `monitor: false` made the problem disappear entirely.

## Root cause

The Railtie starts the agent during Rails init, which under `preload_app!` runs in the **Puma master before fork**. There it spawns the AppServerLoad/background/error-reporting threads, which immediately make HTTPS calls to `checkin.scoutapp.com` / `errors.scoutapm.com`.

`Reporter#http` built its `Net::HTTP` client **without any timeouts**, so when egress to those hosts was momentarily slow, a reporting thread stayed blocked inside a native call (DNS/TLS/read) for up to Net::HTTP's 60s default. If `fork()` fired while that thread held a process-global lock (resolver, OpenSSL, malloc arena, or the `Logger` mutex), the forked worker inherited the lock with no thread alive to release it → deadlock on boot. The race explains the intermittency ("retry sometimes works") and the perfect correlation with `monitor` on/off. The same missing timeout also stalls graceful shutdown/drain, since `at_exit` → `stop_background_worker` joins the worker thread.

## Change

- Set `open_timeout` / `read_timeout` on the reporting connection.
- Make them configurable via new `connect_timeout` / `read_timeout` options (both default **5s**), with coercions and docs.
- This Reporter is shared by the checkin **and** errors paths, so both are covered.

This doesn't depend on correct app-server detection, so it helps every deployment regardless of how Puma is launched. It bounds the dangerous window to a few seconds instead of 60s+, and bounds shutdown.

## Out of scope (follow-up)

The deeper fix — not spawning background threads / doing network I/O in a forking master pre-fork — is a larger lifecycle change and is complicated by the fact that this app is detected as `null` (booted via `bin/rails server`, so `$0` isn't `puma`), meaning a `forking?`-based gate wouldn't even trigger here. Worth a separate PR with its own discussion. The timeout fix above is the safe, universal mitigation.

## Testing

- New `test/unit/reporter_test.rb`: default timeouts, configured overrides, string coercion (env vars), and plain-HTTP endpoints.
- `config_test.rb` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)