### PR TITLE
Pin i18n < 1.15 on Ruby < 3.2 to keep CI deterministic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,11 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", ">= 12.3.3"
+
+# i18n 1.15.0 started using Fiber storage (`Fiber.[]`), which only exists on
+# Ruby 3.2+, so on older Rubies ActiveSupport blew up loading it with
+# `NoMethodError: undefined method '[]' for Fiber:Class` (fixed upstream in
+# 1.15.2). Gemfile.lock is gitignored, so CI resolves i18n fresh each run and is
+# at the mercy of such transient bad releases on the pre-3.2 matrix. Keep those
+# (EOL-track) Rubies pinned to the stable 1.14 line for a deterministic build.
+gem "i18n", "< 1.15" if RUBY_VERSION < "3.2"


### PR DESCRIPTION
## The failure

`test (3.1)` errors during `test_helper` load:

```
NoMethodError: undefined method `[]' for Fiber:Class
  i18n-1.15.0/lib/i18n.rb:58:in `config'
  activesupport-7.2.3.1/lib/active_support/i18n.rb:16
  test/test_helper.rb:12   (require "active_support/core_ext/string/inflections")
```

## Root cause

The pre-3.2 CI lanes use the default `Gemfile`, and `Gemfile.lock` is gitignored — so bundler resolves the latest `i18n` fresh on every run. **i18n 1.15.0** began calling Fiber storage (`Fiber.[]`), which only exists on **Ruby 3.2+**, so on Ruby ≤ 3.1 ActiveSupport fails to load it. (`master`'s last green run predates 1.15.0; it would hit this on a re-run too.)

Upstream fixed it in **i18n 1.15.2**, but the gitignored-lock + unpinned-transitive-dep setup leaves the EOL-track Rubies exposed to the next such release. This caps `i18n < 1.15` only on Ruby < 3.2, keeping those lanes on the stable 1.14 line for a deterministic build. Ruby 3.2+ is untouched and continues to use the latest `i18n`.

## Verification (Docker, `ruby:3.1`)

| Gemfile | resolved i18n | `require "active_support/core_ext/string/inflections"` |
|---|---|---|
| with cap (this PR) | **1.14.8** | **loads OK** |
| no cap (latest) | 1.15.2 | OK (upstream already fixed) |
| no cap @ 1.15.0 (CI on 6/18) | 1.15.0 | `NoMethodError … Fiber:Class` |

`activesupport` 7.2 requires `i18n >= 1.6, < 2`, so 1.14.8 satisfies it cleanly.

## Note / follow-up

The deeper fragility is that the EOL-Ruby matrix resolves bleeding-edge transitive deps from an uncommitted lock, so this class of breakage will recur with other gems. Committing per-lane lockfiles (or pinning) would make CI fully reproducible — out of scope here, happy to do it separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)