### PR TITLE
Use HEROKU_BUILD_COMMIT for Heroku git revision detection

### DIFF
--- a/lib/scout_apm/git_revision.rb
+++ b/lib/scout_apm/git_revision.rb
@@ -26,7 +26,9 @@ module ScoutApm
     end
 
     def detect_from_heroku
-      ENV['HEROKU_SLUG_COMMIT']
+      # HEROKU_SLUG_COMMIT is deprecated in favor of HEROKU_BUILD_COMMIT.
+      # https://devcenter.heroku.com/articles/dyno-metadata#usage
+      ENV['HEROKU_BUILD_COMMIT'] || ENV['HEROKU_SLUG_COMMIT']
     end
 
     # Config will locate the value from:

--- a/test/unit/git_revision_test.rb
+++ b/test/unit/git_revision_test.rb
@@ -34,6 +34,19 @@ class GitRevisionTest < Minitest::Test
     assert_equal 'heroku_slug', revision.sha
   end
 
+  def test_sha_from_heroku_build_commit
+    ENV['HEROKU_BUILD_COMMIT'] = 'heroku_build'
+    revision = ScoutApm::GitRevision.new(ScoutApm::AgentContext.new)
+    assert_equal 'heroku_build', revision.sha
+  end
+
+  def test_sha_from_heroku_prefers_build_commit_over_deprecated_slug_commit
+    ENV['HEROKU_BUILD_COMMIT'] = 'heroku_build'
+    ENV['HEROKU_SLUG_COMMIT'] = 'heroku_slug'
+    revision = ScoutApm::GitRevision.new(ScoutApm::AgentContext.new)
+    assert_equal 'heroku_build', revision.sha
+  end
+
   def test_sha_from_capistrano
     Dir.mktmpdir do |dir|
       context = context_with_file_in_root(File.join(dir, 'REVISION'), 'capistrano_sha')


### PR DESCRIPTION
## Summary

Heroku [deprecated `HEROKU_SLUG_COMMIT`](https://devcenter.heroku.com/articles/dyno-metadata#usage) in favor of `HEROKU_BUILD_COMMIT` (exposed via the `runtime-dyno-build-metadata` lab feature).

This updates `detect_from_heroku` to prefer the new `HEROKU_BUILD_COMMIT`, falling back to the deprecated `HEROKU_SLUG_COMMIT`.

## Changes

- `lib/scout_apm/git_revision.rb` — prefer `HEROKU_BUILD_COMMIT`, fall back to `HEROKU_SLUG_COMMIT`
- `test/unit/git_revision_test.rb` — added tests for the new variable and its precedence over the deprecated one

🤖 Generated with [Claude Code](https://claude.com/claude-code)