### PR TITLE
Fix GraphQL layer leak when unhandled exceptions skip end_execute_field

### DIFF
--- a/lib/scout_apm.rb
+++ b/lib/scout_apm.rb
@@ -102,6 +102,7 @@ require 'scout_apm/instruments/middleware_summary'
 require 'scout_apm/instruments/middleware_detailed' # Disabled by default, see the file for more details
 require 'scout_apm/instruments/rails_router'
 require 'scout_apm/instruments/grape'
+require 'scout_apm/instruments/graphql'
 require 'scout_apm/instruments/sinatra'
 require 'allocations'
 

--- a/lib/scout_apm/instrument_manager.rb
+++ b/lib/scout_apm/instrument_manager.rb
@@ -41,6 +41,7 @@ module ScoutApm
       install_instrument(ScoutApm::Instruments::Elasticsearch)
       install_instrument(ScoutApm::Instruments::OpenSearch)
       install_instrument(ScoutApm::Instruments::Grape)
+      install_instrument(ScoutApm::Instruments::GraphQL)
     rescue
       logger.warn "Exception loading instruments:"
       logger.warn $!.message

--- a/lib/scout_apm/instruments/graphql.rb
+++ b/lib/scout_apm/instruments/graphql.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ScoutApm
+  module Instruments
+    class GraphQL
+      attr_reader :context
+
+      def initialize(context)
+        @context = context
+        @installed = false
+      end
+
+      def logger
+        context.logger
+      end
+
+      def installed?
+        @installed
+      end
+
+      def install(prepend: false)
+        return unless defined?(::GraphQL::Tracing::ScoutTrace)
+
+        @installed = true
+        logger.info "Instrumenting GraphQL::Tracing::ScoutTrace"
+        ::GraphQL::Tracing::ScoutTrace.prepend(ScoutApm::Instruments::GraphQLExecuteFieldGuard)
+      end
+    end
+
+    # Prepended onto GraphQL::Tracing::ScoutTrace to guarantee that every
+    # Scout layer opened during a GraphQL multiplex is closed before control
+    # returns to the Scout Rack middleware.
+    #
+    # graphql-ruby's interpreter calls begin_execute_field / end_execute_field
+    # around each field resolver. When an unhandled exception causes
+    # end_execute_field to be skipped (runtime.rb lines 465-479), the
+    # corresponding ScoutApm::Layer is never popped from TrackedRequest#@layers.
+    # finalized? never returns true, record! is never called, and
+    # Thread.current[:scout_request] accumulates every subsequent request's
+    # layers without bound.
+    #
+    # This guard snapshots the open layer count before executing the multiplex
+    # and pops any excess layers in an ensure block, independent of whichever
+    # internal trace hooks graphql-ruby happens to use. It has no dependency on
+    # MonitorTrace's field-tracing condition or event slot architecture, so it
+    # remains correct even if those internals change.
+    module GraphQLExecuteFieldGuard
+      def execute_multiplex(multiplex:)
+        req = ScoutApm::RequestManager.lookup
+        layers_before = req.layer_count
+        super
+      ensure
+        extra = req.layer_count - layers_before
+        extra.times { req.stop_layer } if extra > 0
+      end
+    end
+  end
+end

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -77,6 +77,10 @@ module ScoutApm
       ignore_request! if @recorder.nil?
     end
 
+    def layer_count
+      @layers.size
+    end
+
     def start_layer(layer)
       # If we're already stopping, don't do additional layers
       return if stopping?


### PR DESCRIPTION
## Fix GraphQL layer leak when unhandled exceptions skip `end_execute_field`

### Problem

When a GraphQL field resolver raises a `StandardError` and the schema has no `rescue_from` handler, graphql-ruby's `handle_or_reraise` re-raises past `end_execute_field` (runtime.rb:479). The matching `ScoutApm::Layer` is never popped from `TrackedRequest#@layers`.

The cascade is worse than one leaked layer:

- `finalized?` never returns true, so `stop_request`/`record!` are never called.
- `Thread.current[:scout_request]` is reused for every later request on that thread (`!stopping? && !recorded?` stays true forever), grafting each subsequent request's entire layer tree onto the stuck root layer and retaining it permanently.
- The process stops reporting **all** data to Scout: zero metrics, traces, and histograms.

In production this showed up as unbounded RSS growth (~100MB/min at 90 req/min) on affected Puma workers, with `histograms_by_time=0` confirming they never completed a recording cycle. Healthy workers kept reporting, masking the loss in the aggregate.

### Fix

`GraphQLExecuteFieldGuard`, prepended onto `GraphQL::Tracing::ScoutTrace` at instrument install. It snapshots `TrackedRequest#layer_count` before `execute_multiplex` and pops any excess layers in an `ensure` block.

Targeting `execute_multiplex` (the outermost trace hook) rather than mirroring graphql-ruby's field-tracing internals keeps it correct regardless of MonitorTrace event/field changes, and makes it a no-op if graphql-ruby fixes the skip upstream.

Also adds `TrackedRequest#layer_count` to expose stack depth without `instance_variable_get`.

### Verification

Reproduced against a Rails 8 / graphql 2.6 app with a resolver raising `StandardError`:

- **Without fix:** 1 poison request + 100 normal → ~650 leaked layers, growing linearly, `finalized?` permanently false.
- **With fix:** same workload → layer count stable across GC cycles, fresh `TrackedRequest` per request, data delivery confirmed.
- Confirmed in the affected customer's production: memory growth stopped and all workers resumed reporting after deploying this branch.

### Notes

- Any `StandardError` subclass in a resolver triggers this (`NoMethodError` on nil, `RecordNotFound`, timeouts). Only `GraphQL::ExecutionError` is handled gracefully by graphql-ruby.
- Customer-side workaround without a gem upgrade: a schema-level `rescue_from(StandardError)` that re-raises as `GraphQL::ExecutionError`.
