### PR TITLE
Honor log level during bootstrap

### DIFF
--- a/lib/scout_apm/agent_context.rb
+++ b/lib/scout_apm/agent_context.rb
@@ -259,7 +259,7 @@ module ScoutApm
     end
 
     def self.build_minimal_logger
-      ScoutApm::Logger.new(nil, :stdout => true)
+      ScoutApm::Logger.new(nil, :stdout => true, :log_level => ENV["SCOUT_LOG_LEVEL"])
     end
   end
 end

--- a/test/unit/agent_context_test.rb
+++ b/test/unit/agent_context_test.rb
@@ -3,6 +3,15 @@ require "test_helper"
 require "scout_apm/agent_context"
 
 class AgentContextTest < Minitest::Test
+  def test_bootstrap_logger_uses_scout_log_level
+    original_log_level = ENV["SCOUT_LOG_LEVEL"]
+    ENV["SCOUT_LOG_LEVEL"] = "error"
+
+    assert_equal ::Logger::ERROR, ScoutApm::AgentContext.new.logger.log_level
+  ensure
+    ENV["SCOUT_LOG_LEVEL"] = original_log_level
+  end
+
   def test_has_error_service_ignored_exceptions
     context = ScoutApm::AgentContext.new
     assert ScoutApm::ErrorService::IgnoredExceptions, context.ignored_exceptions.class


### PR DESCRIPTION
Fixes #627. I tested this on the app that I reported to in that issue and the `INFO : Instrumenting some_method` lines are no longer logged.