### PR TITLE
Version bump 6.2.1

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,11 @@
 # Pending
 
-- Fix `SystemStackError` (stack level too deep) with `grape >= 3.3.0`. Grape now prepends a module in front of `Grape::Endpoint#run`, which is incompatible with the alias-method instrumentation chain; the Grape instrument now honors the `prepend` install option and automatically falls back to `prepend` when `#run` is not owned by `Grape::Endpoint` itself.
+# 6.2.1
+
+- Fix `SystemStackError` with `grape >= 3.3.0` by falling back to `prepend` instrumentation when Grape owns `Endpoint#run` itself (#624)
+- Fix a GraphQL layer leak where an unhandled exception skipping `end_execute_field` could leave stale layers on the request (#626)
+- Honor `SCOUT_LOG_LEVEL` during agent bootstrap instead of always logging at the default level (#628)
+- Use `HEROKU_BUILD_COMMIT` for Heroku git revision detection, since `HEROKU_SLUG_COMMIT` is deprecated (#625)
 
 # 6.2.0
 

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,3 +1,3 @@
 module ScoutApm
-  VERSION = "6.2.0"
+  VERSION = "6.2.1"
 end


### PR DESCRIPTION
## Summary
- Bumps VERSION to 6.2.1
- Moves the pending changelog entries under a 6.2.1 heading and adds brief entries for the other three merged PRs that lacked changelog entries (#626 GraphQL layer leak, #628 log level bootstrap, #625 Heroku build commit)

## Test plan
- [x] Changelog and version file reviewed for accuracy against the underlying merged PRs