### PR TITLE
Fix thread collision with ActionController::Live shared TrackedRequest

### DIFF
--- a/lib/scout_apm/request_manager.rb
+++ b/lib/scout_apm/request_manager.rb
@@ -7,11 +7,23 @@ module ScoutApm
       find || create
     end
 
-    # Get the current Thread local, and detecting, and not returning a stale request
+    # Get the current Thread local, detecting and not returning a stale request,
+    # nor a request that belongs to a different thread.
     def self.find
       req = Thread.current[:scout_request]
+      return nil unless req
 
-      if req && (req.stopping? || req.recorded?)
+      # ActionController::Live runs the controller action in a child thread and
+      # copies the parent thread's raw Thread.current locals (including
+      # :scout_request) into it. Without this check the parent (Rack) thread and
+      # the child (streaming) thread would share and concurrently mutate a single
+      # TrackedRequest -- racing on @layers/@stopping -- which corrupts the layer
+      # stack, drops the transaction, and leaks layers across requests. If the
+      # resident request was created on a different thread, treat it as absent so
+      # lookup creates a fresh one owned by this thread.
+      return nil if req.creating_thread_id != Thread.current.object_id
+
+      if req.stopping? || req.recorded?
         nil
       else
         req

--- a/lib/scout_apm/tracked_request.rb
+++ b/lib/scout_apm/tracked_request.rb
@@ -74,8 +74,19 @@ module ScoutApm
       @recorder = agent_context.recorder
       @real_request = false
       @transaction_id = ScoutApm::Utils::TransactionId.new.to_s
+      # The thread this request was created on. ActionController::Live copies the
+      # raw Thread.current locals (including :scout_request) into its streaming
+      # child thread, which would otherwise cause two threads to share and race
+      # on one TrackedRequest. RequestManager uses this to detect an inherited
+      # request and give the child its own instead. See RequestManager.find.
+      @creating_thread_id = Thread.current.object_id
       ignore_request! if @recorder.nil?
     end
+
+    # The object_id of the Thread that created this request. Used to detect a
+    # TrackedRequest that was inherited by a different thread (e.g. an
+    # ActionController::Live streaming thread) rather than created for it.
+    attr_reader :creating_thread_id
 
     def layer_count
       @layers.size

--- a/test/unit/request_manager_test.rb
+++ b/test/unit/request_manager_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+# Tests for RequestManager's thread-local handling, in particular that a
+# TrackedRequest created on one thread is NOT shared with another thread.
+#
+# ActionController::Live runs the controller action in a child thread and copies
+# the parent (Rack) thread's raw Thread.current locals -- including
+# :scout_request -- into it. Without protection both threads would share and
+# concurrently mutate a single TrackedRequest, racing on @layers/@stopping,
+# which drops the transaction and leaks layers. RequestManager must give the
+# inheriting thread its own request instead.
+class RequestManagerTest < Minitest::Test
+  def teardown
+    # Never let a test leak the thread-local into sibling tests.
+    Thread.current[:scout_request] = nil
+  end
+
+  def test_lookup_reuses_the_request_on_the_same_thread
+    first  = ScoutApm::RequestManager.lookup
+    second = ScoutApm::RequestManager.lookup
+
+    assert_same first, second,
+      "lookup should return the same TrackedRequest on repeated calls within one thread"
+  end
+
+  def test_lookup_in_a_child_thread_that_inherited_the_local_gets_its_own_request
+    parent_request = ScoutApm::RequestManager.lookup
+    inherited = Thread.current[:scout_request]
+
+    child_request = nil
+    child_local_before = nil
+
+    t = Thread.new do
+      # Simulate ActionController::Live copying the parent's raw thread local
+      # into the streaming child thread.
+      Thread.current[:scout_request] = inherited
+      child_local_before = Thread.current[:scout_request]
+
+      child_request = ScoutApm::RequestManager.lookup
+    end
+    t.join
+
+    # The child observed the inherited (parent's) request as its raw local...
+    assert_same parent_request, child_local_before
+
+    # ...but lookup must NOT hand it the parent's request to mutate.
+    refute_nil child_request
+    refute_same parent_request, child_request,
+      "a thread that inherited another thread's :scout_request must get its own TrackedRequest"
+
+    # And the parent's request must be left untouched (still the parent's).
+    assert_same parent_request, Thread.current[:scout_request]
+  end
+
+  def test_find_treats_a_foreign_thread_request_as_absent
+    # A request that reports it was created on a different thread should not be
+    # returned by find (so lookup falls through to create).
+    foreign = ScoutApm::TrackedRequest.new(ScoutApm::Agent.instance.context, ScoutApm::FakeStore.new)
+    foreign.stubs(:creating_thread_id).returns(Thread.current.object_id + 1)
+    Thread.current[:scout_request] = foreign
+
+    assert_nil ScoutApm::RequestManager.find,
+      "find should treat a request created on another thread as absent"
+  end
+
+  def test_find_returns_a_same_thread_request
+    own = ScoutApm::RequestManager.lookup
+    assert_same own, ScoutApm::RequestManager.find
+  end
+end


### PR DESCRIPTION
## Problem

On Rails 8 / Rack 3, requests served via `ActionController::Live` (for example **ActiveStorage proxy** representations and blobs) could be under-reported — web transactions on those streaming endpoints would intermittently not show up, and a request's layers could carry over to later requests on the same thread.

## Cause

`ActionController::Live` runs the controller action in a separate child thread and copies the parent thread's raw `Thread.current` locals into it, including Scout's `:scout_request`. (`live_streaming_excluded_keys` only applies to `ActiveSupport::IsolatedExecutionState`, not raw thread-locals.) The parent and child thread then share a single `TrackedRequest` and can mutate its layer stack concurrently, which can cause the transaction to be recorded without its Controller layer and can leave layers on the stack that get reused by later requests on that thread.

## Fix

Stamp each `TrackedRequest` with the id of the thread that created it. `RequestManager.find` now treats a request created on a different thread as absent, so a thread that inherited another thread's `:scout_request` (such as a `Live` streaming thread) gets its own `TrackedRequest`. This is a no-op for ordinary single-threaded requests.

## Testing

Adds `test/unit/request_manager_test.rb`, which reproduces the `ActionController::Live` pattern (copying `:scout_request` into a child thread) and asserts the child receives its own `TrackedRequest` while the parent's is left intact. The test fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)