### PR TITLE
Version bump 6.3.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # Pending
 
+# 6.3.0
+
+- Fix span leak on `ActionController::Live` streaming requests (#631)
+
 # 6.2.1
 
 - Fix `SystemStackError` with `grape >= 3.3.0` by falling back to `prepend` instrumentation when Grape owns `Endpoint#run` itself (#624)

--- a/lib/scout_apm/version.rb
+++ b/lib/scout_apm/version.rb
@@ -1,3 +1,3 @@
 module ScoutApm
-  VERSION = "6.2.1"
+  VERSION = "6.3.0"
 end


### PR DESCRIPTION
## 6.3.0

- Fix span leak on `ActionController::Live` streaming requests (#631)